### PR TITLE
OSL-198: removing `status` from `CreateShareableListInput`

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -27,12 +27,12 @@ type ShareableListItem {
 	imageUrl: Url
 	authors: String
 	sortOrder: Int!
-  createdAt: ISOString!
-  updatedAt: ISOString!
+	createdAt: ISOString!
+	updatedAt: ISOString!
 }
 
 type ShareableList {
-  externalId: String!
+	externalId: String!
 	slug: String!
 	title: String!
 	description: String
@@ -46,17 +46,16 @@ type ShareableList {
 input CreateShareableListInput {
 	title: String!
 	description: String
-	status: ShareableListStatus
 }
 
 type Query {
 	lists: [ShareableList]
 
-  """
-  Looks up and returns a Shareable List with a given external ID for a given user
-  (the user ID will be coming through with the headers)
-  """
-  shareableList(externalId: String!): ShareableList
+	"""
+	Looks up and returns a Shareable List with a given external ID for a given user
+	(the user ID will be coming through with the headers)
+	"""
+	shareableList(externalId: String!): ShareableList
 }
 
 type Mutation {

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -1,4 +1,4 @@
-import { List, ListItem, ListStatus } from '@prisma/client';
+import { List, ListItem } from '@prisma/client';
 
 /**
  * These are the properties of list items exposed on the public Pocket Graph -

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -24,5 +24,4 @@ export type ShareableList = Omit<
 export type CreateShareableListInput = {
   title: string;
   description?: string;
-  status?: ListStatus;
 };


### PR DESCRIPTION
## Goal

`Status` by default is always `PRIVATE` when creating a `List`, so removing `Status` from the body.

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-198](https://getpocket.atlassian.net/browse/OSL-198)