### PR TITLE
feat(mutation): [OSL-102] Add `updateShareableList` mutation

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -33,7 +33,7 @@ type ShareableListItem {
 
 type ShareableList {
 	externalId: String!
-	slug: String!
+	slug: String
 	title: String!
 	description: String
 	status: ShareableListStatus!
@@ -46,6 +46,13 @@ type ShareableList {
 input CreateShareableListInput {
 	title: String!
 	description: String
+}
+
+input UpdateShareableListInput {
+    externalId: String!
+    title: String
+    description: String
+    status: ShareableListStatus
 }
 
 type Query {
@@ -63,4 +70,8 @@ type Mutation {
 	Creates a Shareable List
 	"""
 	createShareableList(data: CreateShareableListInput!): ShareableList
+  """
+  Updates a Shareable List. This includes making it public.
+  """
+  updateShareableList(data: UpdateShareableListInput!): ShareableList!
 }

--- a/src/database/mutations.ts
+++ b/src/database/mutations.ts
@@ -1,2 +1,3 @@
 // provide a single file to use for imports
 export { createShareableList } from './mutations/ShareableList';
+export { updateShareableList } from './mutations/ShareableList';

--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -1,6 +1,13 @@
-import { UserInputError } from '@pocket-tools/apollo-utils';
-import { PrismaClient } from '@prisma/client';
-import { CreateShareableListInput, ShareableList } from '../types';
+import { NotFoundError, UserInputError } from '@pocket-tools/apollo-utils';
+import { ListStatus, PrismaClient } from '@prisma/client';
+import slugify from 'slugify';
+import {
+  CreateShareableListInput,
+  ShareableList,
+  UpdateShareableListInput,
+} from '../types';
+import { getShareableList } from '../queries';
+import config from '../../config';
 
 /**
  * This mutation creates a shareable list, and _only_ a shareable list
@@ -27,6 +34,71 @@ export async function createShareableList(
 
   return db.list.create({
     data: { ...data, userId },
+    include: {
+      listItems: true,
+    },
+  });
+}
+
+/**
+ * This mutation updates a shareable list, including making it public.
+ *
+ * @param db
+ * @param data
+ * @param userId
+ */
+export async function updateShareableList(
+  db: PrismaClient,
+  data: UpdateShareableListInput,
+  userId: number | bigint
+): Promise<ShareableList> {
+  // Retrieve the current record, pre-update
+  const list = await getShareableList(db, userId, data.externalId);
+
+  if (!list) {
+    throw new NotFoundError(`A list by that ID could not be found`);
+  }
+
+  // If the title is getting updated, check if the user already has a list
+  // with the same title.
+  if (data.title) {
+    const titleExists = await db.list.count({
+      where: { title: data.title, userId: userId },
+    });
+
+    if (titleExists) {
+      throw new UserInputError(
+        `A list with the title "${data.title}" already exists`
+      );
+    }
+  }
+
+  // If there is no slug and the list is being shared with the world,
+  // let's generate a slug from the title with a string of random numbers
+  // at the end.
+  if (data.status === ListStatus.PUBLIC && !list.slug) {
+    // If an updated title is provided, generate the slug from that,
+    // otherwise default to the title saved previously.
+    data.slug = slugify(data.title ?? list.title, config.slugify);
+
+    // Append a dash and a random ten-digit number at the end of the slug.
+    data.slug += `-${parseInt(String(Math.random() * 10000000000), 10)}`;
+
+    // Verify that this slug is unique to this user
+    const slugExists = await db.list.count({
+      where: { slug: data.slug, userId: userId },
+    });
+
+    if (slugExists) {
+      throw new UserInputError(
+        `A list with the slug "${data.slug}" already exists`
+      );
+    }
+  }
+
+  return db.list.update({
+    data,
+    where: { externalId: data.externalId },
     include: {
       listItems: true,
     },

--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -74,26 +74,12 @@ export async function updateShareableList(
   }
 
   // If there is no slug and the list is being shared with the world,
-  // let's generate a slug from the title with a string of random numbers
-  // at the end.
+  // let's generate a slug from the title. Once set, it will not be
+  // updated to sync with any further title edits.
   if (data.status === ListStatus.PUBLIC && !list.slug) {
     // If an updated title is provided, generate the slug from that,
     // otherwise default to the title saved previously.
     data.slug = slugify(data.title ?? list.title, config.slugify);
-
-    // Append a dash and a random ten-digit number at the end of the slug.
-    data.slug += `-${parseInt(String(Math.random() * 10000000000), 10)}`;
-
-    // Verify that this slug is unique to this user
-    const slugExists = await db.list.count({
-      where: { slug: data.slug, userId: userId },
-    });
-
-    if (slugExists) {
-      throw new UserInputError(
-        `A list with the slug "${data.slug}" already exists`
-      );
-    }
   }
 
   return db.list.update({

--- a/src/database/queries/ShareableList.ts
+++ b/src/database/queries/ShareableList.ts
@@ -22,27 +22,8 @@ export async function getShareableList(
       externalId,
       moderationStatus: ModerationStatus.VISIBLE,
     },
-    select: {
-      externalId: true,
-      slug: true,
-      title: true,
-      description: true,
-      status: true,
-      moderationStatus: true,
-      createdAt: true,
-      updatedAt: true,
-      listItems: {
-        select: {
-          url: true,
-          title: true,
-          excerpt: true,
-          imageUrl: true,
-          authors: true,
-          sortOrder: true,
-          createdAt: true,
-          updatedAt: true,
-        },
-      },
+    include: {
+      listItems: true,
     },
   });
 }

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -1,4 +1,4 @@
-import { List, ListItem } from '@prisma/client';
+import { List, ListItem, ListStatus } from '@prisma/client';
 
 /**
  * These are the properties of list items exposed on the public Pocket Graph -
@@ -17,11 +17,20 @@ export type ShareableList = Omit<
   List,
   'id' | 'userId' | 'moderatedBy' | 'moderationReason'
 > & {
-  // optional as not needed for returning when creating a ShareableList atm
   listItems?: ShareableListItem[];
 };
 
 export type CreateShareableListInput = {
   title: string;
   description?: string;
+};
+
+export type UpdateShareableListInput = {
+  externalId: string;
+  title?: string;
+  description?: string;
+  status?: ListStatus;
+  // Not in the public schema but here in the DB input type
+  // because it's generated in the DB resolver if required.
+  slug?: string;
 };

--- a/src/public/resolvers/fieldResolvers.ts
+++ b/src/public/resolvers/fieldResolvers.ts
@@ -1,0 +1,22 @@
+/**
+ * Field-level resolvers for the public ShareableList type.
+ */
+import { ShareableList } from '../../database/types';
+import { getShareableList } from '../../database/queries';
+
+export const shareableListFieldResolvers = {
+  async slug(parent: ShareableList, _, { db, userId }): Promise<string> {
+    if (!parent.slug) {
+      // If a slug is not set, let's not touch it at all.
+      return null;
+    } else {
+      // Compose the slug value out of the stored value for it
+      // and a portion of the UUID string for `externalId`
+      const list = await getShareableList(db, userId, parent.externalId);
+      return `${list.slug}-${list.externalId.substring(
+        0,
+        list.externalId.indexOf('-')
+      )}`;
+    }
+  },
+};

--- a/src/public/resolvers/fragments.gql.ts
+++ b/src/public/resolvers/fragments.gql.ts
@@ -1,0 +1,39 @@
+import { gql } from 'graphql-tag';
+
+/**
+ * This GraphQL fragment contains all the properties that must be available
+ * in the Pocket Graph for a Shareable List Item.
+ */
+export const ShareableListItemPublicProps = gql`
+  fragment ShareableListItemPublicProps on ShareableListItem {
+    url
+    title
+    excerpt
+    imageUrl
+    authors
+    sortOrder
+    createdAt
+    updatedAt
+  }
+`;
+
+/**
+ * This GraphQL fragment contains all the properties that must be available
+ * in the Pocket Graph for a Shareable List.
+ */
+export const ShareableListPublicProps = gql`
+  fragment ShareableListPublicProps on ShareableList {
+    externalId
+    title
+    description
+    slug
+    status
+    moderationStatus
+    createdAt
+    updatedAt
+    listItems {
+      ...ShareableListItemPublicProps
+    }
+  }
+  ${ShareableListItemPublicProps}
+`;

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -4,6 +4,7 @@ import {
   createShareableList,
   updateShareableList,
 } from './mutations/ShareableList';
+import { shareableListFieldResolvers } from './fieldResolvers';
 
 // dummy data -- this is temporary
 const listData = [];
@@ -33,6 +34,7 @@ function lists(): any {
 }
 
 export const resolvers = {
+  ShareableList: shareableListFieldResolvers,
   Mutation: { createShareableList, updateShareableList },
   Query: {
     lists,

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -1,6 +1,9 @@
 import { faker } from '@faker-js/faker';
 import { getShareableList } from './queries/ShareableList';
-import { createShareableList } from './mutations/ShareableList';
+import {
+  createShareableList,
+  updateShareableList,
+} from './mutations/ShareableList';
 
 // dummy data -- this is temporary
 const listData = [];
@@ -30,7 +33,7 @@ function lists(): any {
 }
 
 export const resolvers = {
-  Mutation: { createShareableList },
+  Mutation: { createShareableList, updateShareableList },
   Query: {
     lists,
     shareableList: getShareableList,

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -324,8 +324,8 @@ describe('public mutations: ShareableList', () => {
         slugify(updatedList.title, config.slugify)
       );
 
-      // Does the slug have a dash and 10 digits at the end?
-      expect(updatedList.slug).to.match(/-\d{10}$/);
+      // Does the slug have a dash and 8 alphanumeric characters at the end?
+      expect(updatedList.slug).to.match(/-[a-z\d]{8}$/);
     });
 
     it('should generate a slug from updated title if one is provided', async () => {
@@ -357,8 +357,8 @@ describe('public mutations: ShareableList', () => {
       // Does the slug match the updated title?
       expect(updatedList.slug).to.contain(slugify(data.title, config.slugify));
 
-      // Does the slug have a dash and 10 digits at the end?
-      expect(updatedList.slug).to.match(/-\d{10}$/);
+      // Does the slug have a dash and 8 alphanumeric characters at the end?
+      expect(updatedList.slug).to.match(/-[a-z\d]{8}$/);
     });
 
     it('should not update the slug once set if any other updates are made', async () => {

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -6,10 +6,23 @@ import { startServer } from '../../../express';
 import { IPublicContext } from '../../context';
 import { faker } from '@faker-js/faker';
 import { client } from '../../../database/client';
-import { ListStatus, ModerationStatus, PrismaClient } from '@prisma/client';
-import { CreateShareableListInput } from '../../../database/types';
-import { CREATE_SHAREABLE_LIST } from './sample-mutations.gql';
+import {
+  List,
+  ListStatus,
+  ModerationStatus,
+  PrismaClient,
+} from '@prisma/client';
+import {
+  CreateShareableListInput,
+  UpdateShareableListInput,
+} from '../../../database/types';
+import {
+  CREATE_SHAREABLE_LIST,
+  UPDATE_SHAREABLE_LIST,
+} from './sample-mutations.gql';
 import { clearDb, createShareableListHelper } from '../../../test/helpers';
+import slugify from 'slugify';
+import config from '../../../config';
 
 describe('public mutations: ShareableList', () => {
   let app: Express.Application;
@@ -48,6 +61,7 @@ describe('public mutations: ShareableList', () => {
         title: 'Simon Le Bon List',
       });
     });
+
     it('should create a new List', async () => {
       const title = faker.random.words(2);
       const data: CreateShareableListInput = {
@@ -70,6 +84,7 @@ describe('public mutations: ShareableList', () => {
         ModerationStatus.VISIBLE
       );
     });
+
     it('should not create List with existing title for the same userId', async () => {
       const list1 = await createShareableListHelper(db, {
         title: `Katerina's List`,
@@ -94,6 +109,7 @@ describe('public mutations: ShareableList', () => {
         `A list with the title "Katerina's List" already exists`
       );
     });
+
     it('should create List with existing title in db but for different userId', async () => {
       const list1 = await createShareableListHelper(db, {
         title: `Best Abstraction Art List`,
@@ -121,6 +137,7 @@ describe('public mutations: ShareableList', () => {
         ModerationStatus.VISIBLE
       );
     });
+
     it('should create List with a missing description', async () => {
       // create new List with a missing description
       const data: CreateShareableListInput = {
@@ -144,6 +161,241 @@ describe('public mutations: ShareableList', () => {
       expect(result.body.data.createShareableList.moderationStatus).to.equal(
         ModerationStatus.VISIBLE
       );
+    });
+  });
+
+  describe('updateShareableList', () => {
+    let listToUpdate: List;
+
+    beforeEach(async () => {
+      // Create a List
+      listToUpdate = await createShareableListHelper(db, {
+        userId: parseInt(headers.userId),
+        title: 'The Most Shareable List',
+      });
+    });
+
+    it('should update a list and return all props', async () => {
+      const data: UpdateShareableListInput = {
+        externalId: listToUpdate.externalId,
+        title: 'This Will Be A Brand New Title',
+        description: faker.lorem.sentences(2),
+        status: ListStatus.PRIVATE,
+      };
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_SHAREABLE_LIST),
+          variables: { data },
+        });
+
+      // There should be no errors
+      expect(result.body.errors).to.be.undefined;
+
+      // A result should be returned
+      expect(result.body.data.updateShareableList).not.to.be.null;
+
+      // Verify that all optional properties have been updated
+      const updatedList = result.body.data.updateShareableList;
+      expect(updatedList.title).to.equal(data.title);
+      expect(updatedList.description).to.equal(data.description);
+      expect(updatedList.status).to.equal(data.status);
+
+      // Check that props that shouldn't have changed stayed the same
+      expect(updatedList.slug).to.equal(listToUpdate.slug);
+      expect(updatedList.moderationStatus).to.equal(
+        listToUpdate.moderationStatus
+      );
+      expect(updatedList.createdAt).to.equal(
+        listToUpdate.createdAt.toISOString()
+      );
+      expect(updatedList.listItems).to.have.lengthOf(0);
+
+      // The `updatedAt` timestamp should change
+      expect(updatedList.updatedAt).not.to.equal(
+        listToUpdate.updatedAt.toISOString()
+      );
+    });
+
+    it('should return a "Not Found" error if no list exists', async () => {
+      const data: UpdateShareableListInput = {
+        externalId: 'this-will-never-be-found',
+        title: 'This Will Never Get Into The Database',
+      };
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_SHAREABLE_LIST),
+          variables: { data },
+        });
+
+      // There should be nothing in results
+      expect(result.body.data).to.be.null;
+
+      // And a "Not found" error
+      expect(result.body).to.have.nested.property(
+        'errors[0].extensions.code',
+        'NOT_FOUND'
+      );
+    });
+
+    it('should reject the update if user already has a list with the same title', async () => {
+      const anotherListProps = {
+        userId: parseInt(headers.userId),
+        title: 'A Very Popular Title',
+      };
+      await createShareableListHelper(db, anotherListProps);
+
+      const data: UpdateShareableListInput = {
+        externalId: listToUpdate.externalId,
+        title: anotherListProps.title,
+      };
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_SHAREABLE_LIST),
+          variables: { data },
+        });
+
+      // There should be nothing in results
+      expect(result.body.data).to.be.null;
+
+      // And a "Bad user input" error
+      expect(result.body).to.have.nested.property(
+        'errors[0].extensions.code',
+        'BAD_USER_INPUT'
+      );
+    });
+
+    it('should generate a slug if a list is being made public for the first time', async () => {
+      const data: UpdateShareableListInput = {
+        externalId: listToUpdate.externalId,
+        status: ListStatus.PUBLIC,
+      };
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_SHAREABLE_LIST),
+          variables: { data },
+        });
+
+      // There should be no errors
+      expect(result.body.errors).to.be.undefined;
+
+      // A result should be returned
+      expect(result.body.data.updateShareableList).not.to.be.null;
+
+      // Verify that the updates have taken place
+      const updatedList = result.body.data.updateShareableList;
+      expect(updatedList.status).to.equal(ListStatus.PUBLIC);
+      expect(updatedList.slug).not.to.be.empty;
+
+      // Does the slug match the current title?
+      expect(updatedList.slug).to.contain(
+        slugify(updatedList.title, config.slugify)
+      );
+
+      // Does the slug have a dash and 10 digits at the end?
+      expect(updatedList.slug).to.match(/-\d{10}$/);
+    });
+
+    it('should generate a slug from updated title if one is provided', async () => {
+      const data: UpdateShareableListInput = {
+        externalId: listToUpdate.externalId,
+        title: 'This Title is Different',
+        status: ListStatus.PUBLIC,
+      };
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_SHAREABLE_LIST),
+          variables: { data },
+        });
+
+      // There should be no errors
+      expect(result.body.errors).to.be.undefined;
+
+      // A result should be returned
+      expect(result.body.data.updateShareableList).not.to.be.null;
+
+      // Verify that the updates have taken place
+      const updatedList = result.body.data.updateShareableList;
+      expect(updatedList.status).to.equal(ListStatus.PUBLIC);
+      expect(updatedList.slug).not.to.be.empty;
+
+      // Does the slug match the updated title?
+      expect(updatedList.slug).to.contain(slugify(data.title, config.slugify));
+
+      // Does the slug have a dash and 10 digits at the end?
+      expect(updatedList.slug).to.match(/-\d{10}$/);
+    });
+
+    it('should not update the slug once set if any other updates are made', async () => {
+      // Run through the steps to publish the list and update the slug
+      const data: UpdateShareableListInput = {
+        externalId: listToUpdate.externalId,
+        title: 'This Title Could Not Be More Different',
+        status: ListStatus.PUBLIC,
+      };
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_SHAREABLE_LIST),
+          variables: { data },
+        });
+
+      // There should be no errors
+      expect(result.body.errors).to.be.undefined;
+
+      // A result should be returned
+      expect(result.body.data.updateShareableList).not.to.be.null;
+
+      // Let's save the list in this updated state
+      const listWithSlugSet = result.body.data.updateShareableList;
+
+      // Now update the title, status, description and see if anything happens
+      // to the slug
+      const data2: UpdateShareableListInput = {
+        externalId: listToUpdate.externalId,
+        title: 'Suddenly This List is Private Again',
+        description: 'I really should have kept this to myself',
+        status: ListStatus.PRIVATE,
+      };
+
+      const result2 = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_SHAREABLE_LIST),
+          variables: { data: data2 },
+        });
+
+      // There should be no errors
+      expect(result2.body.errors).to.be.undefined;
+
+      // A result should be returned
+      expect(result2.body.data.updateShareableList).not.to.be.null;
+
+      // Verify that the updates have taken place
+      const updatedList = result2.body.data.updateShareableList;
+      expect(updatedList.status).to.equal(ListStatus.PRIVATE);
+      expect(updatedList.title).to.equal(data2.title);
+      expect(updatedList.description).to.equal(data2.description);
+
+      // Is the slug unchanged? It should be!
+      expect(updatedList.slug).to.equal(listWithSlugSet.slug);
     });
   });
 });

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -324,8 +324,10 @@ describe('public mutations: ShareableList', () => {
         slugify(updatedList.title, config.slugify)
       );
 
-      // Does the slug have a dash and 8 alphanumeric characters at the end?
-      expect(updatedList.slug).to.match(/-[a-z\d]{8}$/);
+      // Does the slug contain the first 8 characters of the externalId?
+      expect(updatedList.slug).to.contain(
+        updatedList.externalId.substring(0, updatedList.externalId.indexOf('-'))
+      );
     });
 
     it('should generate a slug from updated title if one is provided', async () => {
@@ -357,8 +359,10 @@ describe('public mutations: ShareableList', () => {
       // Does the slug match the updated title?
       expect(updatedList.slug).to.contain(slugify(data.title, config.slugify));
 
-      // Does the slug have a dash and 8 alphanumeric characters at the end?
-      expect(updatedList.slug).to.match(/-[a-z\d]{8}$/);
+      // Does the slug contain the first 8 characters of the externalId?
+      expect(updatedList.slug).to.contain(
+        updatedList.externalId.substring(0, updatedList.externalId.indexOf('-'))
+      );
     });
 
     it('should not update the slug once set if any other updates are made', async () => {

--- a/src/public/resolvers/mutations/ShareableList.ts
+++ b/src/public/resolvers/mutations/ShareableList.ts
@@ -43,7 +43,8 @@ export async function createShareableList(
 }
 
 /**
- * Works out what to send to the up
+ * The update list mutation. Handles everything, including toggling the list
+ * between PRIVATE and PUBLIC.
  *
  * @param parent
  * @param data

--- a/src/public/resolvers/mutations/ShareableList.ts
+++ b/src/public/resolvers/mutations/ShareableList.ts
@@ -1,8 +1,12 @@
 import {
   CreateShareableListInput,
   ShareableList,
+  UpdateShareableListInput,
 } from '../../../database/types';
-import { createShareableList as dbCreateShareableList } from '../../../database/mutations';
+import {
+  createShareableList as dbCreateShareableList,
+  updateShareableList as dbUpdateShareableList,
+} from '../../../database/mutations';
 import { IPublicContext } from '../../context';
 
 /**
@@ -35,5 +39,24 @@ export async function createShareableList(
     context,
     data,
     dbCreateShareableList
+  );
+}
+
+/**
+ * Works out what to send to the up
+ *
+ * @param parent
+ * @param data
+ * @param context
+ */
+export async function updateShareableList(
+  parent,
+  { data },
+  context: IPublicContext
+): Promise<ShareableList> {
+  return await executeMutation<UpdateShareableListInput, ShareableList>(
+    context,
+    data,
+    dbUpdateShareableList
   );
 }

--- a/src/public/resolvers/mutations/sample-mutations.gql.ts
+++ b/src/public/resolvers/mutations/sample-mutations.gql.ts
@@ -1,12 +1,20 @@
 import { gql } from 'graphql-tag';
+import { ShareableListPublicProps } from '../fragments.gql';
 
 export const CREATE_SHAREABLE_LIST = gql`
   mutation createShareableList($data: CreateShareableListInput!) {
     createShareableList(data: $data) {
-      title
-      description
-      status
-      moderationStatus
+      ...ShareableListPublicProps
     }
   }
+  ${ShareableListPublicProps}
+`;
+
+export const UPDATE_SHAREABLE_LIST = gql`
+  mutation updateShareableList($data: UpdateShareableListInput!) {
+    updateShareableList(data: $data) {
+      ...ShareableListPublicProps
+    }
+  }
+  ${ShareableListPublicProps}
 `;

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -51,7 +51,6 @@ describe('public queries: ShareableList', () => {
     shareableList = await createShareableListHelper(db, {
       userId: parseInt(headers.userId),
       title: 'This is a test list',
-      slug: 'this-is-a-test-list-89674523',
     });
   });
 
@@ -101,7 +100,6 @@ describe('public queries: ShareableList', () => {
 
       // Values we know as we've assigned them manually
       expect(list.title).to.equal(shareableList.title);
-      expect(list.slug).to.equal(shareableList.slug);
       expect(list.description).to.equal(shareableList.description);
 
       // Default status values
@@ -113,6 +111,9 @@ describe('public queries: ShareableList', () => {
       expect(list.createdAt).not.to.be.empty;
       expect(list.updatedAt).not.to.be.empty;
       expect(list.externalId).not.to.be.empty;
+
+      // Empty slug - it's not generated on creation
+      expect(list.slug).to.be.null;
 
       // Empty list items array
       expect(list.listItems).to.have.lengthOf(0);

--- a/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/src/public/resolvers/queries/sample-queries.gql.ts
@@ -1,28 +1,13 @@
 import { gql } from 'graphql-tag';
+import { ShareableListPublicProps } from '../fragments.gql';
 
 export const GET_SHAREABLE_LIST = gql`
   query shareableList($externalId: String!) {
     shareableList(externalId: $externalId) {
-      externalId
-      slug
-      title
-      description
-      status
-      moderationStatus
-      createdAt
-      updatedAt
-      listItems {
-        url
-        title
-        excerpt
-        imageUrl
-        authors
-        sortOrder
-        createdAt
-        updatedAt
-      }
+      ...ShareableListPublicProps
     }
   }
+  ${ShareableListPublicProps}
 `;
 
 export const GET_LISTS = gql`

--- a/src/test/helpers/createShareableListHelper.ts
+++ b/src/test/helpers/createShareableListHelper.ts
@@ -6,7 +6,6 @@ import config from '../../config';
 interface ListHelperInput {
   userId: number | bigint;
   title: string;
-  slug?: string;
   description?: string;
 }
 
@@ -21,12 +20,10 @@ export async function createShareableListHelper(
   data: ListHelperInput
 ): Promise<List> {
   const listTitle = data.title ?? faker.random.words(2);
-  const listSlug = data.slug ?? slugify(listTitle, config.slugify);
 
   const input: ListHelperInput = {
     userId: data.userId ?? faker.datatype.number(),
     title: listTitle,
-    slug: listSlug,
     description: data.description ?? faker.lorem.sentences(2),
   };
 

--- a/src/test/helpers/createShareableListHelper.ts
+++ b/src/test/helpers/createShareableListHelper.ts
@@ -1,7 +1,5 @@
 import { List, PrismaClient } from '@prisma/client';
 import { faker } from '@faker-js/faker';
-import slugify from 'slugify';
-import config from '../../config';
 
 interface ListHelperInput {
   userId: number | bigint;


### PR DESCRIPTION
## Goal

Unblock the Web team by adding another mutation to the public graph.

- Added the mutation and integration tests.

- Updated `createShareableListHelper` to no longer generate slugs as they need to be set on publishing the list, not on initial list creation.

- Updated existing tests to cater for that.

- Refactored queries and mutations used in integration tests to use fragments to make sure each operation consistently returns all public values for lists and list items.



## I'd love to get feedback on

- Whether I've covered all edge cases both in code and tests.

## Tickets

- https://getpocket.atlassian.net/browse/OSL-102