### PR TITLE
NO-TICKET: Turning off the error formatter

### DIFF
--- a/src/admin/server.ts
+++ b/src/admin/server.ts
@@ -3,7 +3,8 @@ import { Server } from 'http';
 import { buildSubgraphSchema } from '@apollo/subgraph';
 import { typeDefsAdmin } from '../typeDefs';
 import { resolvers as adminResolvers } from './resolvers';
-import { errorHandler, sentryPlugin } from '@pocket-tools/apollo-utils';
+// import { errorHandler, sentryPlugin } from '@pocket-tools/apollo-utils';
+import { sentryPlugin } from '@pocket-tools/apollo-utils';
 import { ApolloServerPluginLandingPageGraphQLPlayground } from '@apollo/server-plugin-landing-page-graphql-playground';
 import {
   ApolloServerPluginLandingPageDisabled,
@@ -48,7 +49,10 @@ export function getAdminServer(
       { typeDefs: typeDefsAdmin, resolvers: adminResolvers },
     ]),
     plugins,
-    formatError: errorHandler,
+    // Turning off the formatter for now as the web team needs to get the errors unmasked.
+    // OSL-202 (https://getpocket.atlassian.net/browse/OSL-202) needs to get done in order
+    // to turn back on the formatter.
+    // formatError: errorHandler,
   });
 }
 

--- a/src/public/server.ts
+++ b/src/public/server.ts
@@ -1,7 +1,8 @@
 import { ApolloServer } from '@apollo/server';
 import { Server } from 'http';
 import { buildSubgraphSchema } from '@apollo/subgraph';
-import { errorHandler, sentryPlugin } from '@pocket-tools/apollo-utils';
+// import { errorHandler, sentryPlugin } from '@pocket-tools/apollo-utils';
+import { sentryPlugin } from '@pocket-tools/apollo-utils';
 import { ApolloServerPluginLandingPageGraphQLPlayground } from '@apollo/server-plugin-landing-page-graphql-playground';
 import {
   ApolloServerPluginLandingPageDisabled,
@@ -41,7 +42,10 @@ export function getPublicServer(
   return new ApolloServer<IPublicContext>({
     schema: buildSubgraphSchema([{ typeDefs: typeDefsPublic, resolvers }]),
     plugins,
-    formatError: errorHandler,
+    // Turning off the formatter for now as the web team needs to get the errors unmasked.
+    // OSL-202 (https://getpocket.atlassian.net/browse/OSL-202) needs to get done in order
+    // to turn back on the formatter.
+    // formatError: errorHandler,
   });
 }
 


### PR DESCRIPTION
## Goal

Turning off the formatter for now as the web team needs to get the errors unmasked.
 [OSL-202](https://getpocket.atlassian.net/browse/OSL-202) needs to get done in order to turn back on the formatter.

## Todos

- [ ] deploy to dev to test that errors are unmasked before merging.

[OSL-202]: https://getpocket.atlassian.net/browse/OSL-202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ