### PR TITLE
NO-TICKET: turning the apollo utils errorFormatter back on

### DIFF
--- a/src/admin/server.ts
+++ b/src/admin/server.ts
@@ -3,8 +3,7 @@ import { Server } from 'http';
 import { buildSubgraphSchema } from '@apollo/subgraph';
 import { typeDefsAdmin } from '../typeDefs';
 import { resolvers as adminResolvers } from './resolvers';
-// import { errorHandler, sentryPlugin } from '@pocket-tools/apollo-utils';
-import { sentryPlugin } from '@pocket-tools/apollo-utils';
+import { errorHandler, sentryPlugin } from '@pocket-tools/apollo-utils';
 import { ApolloServerPluginLandingPageGraphQLPlayground } from '@apollo/server-plugin-landing-page-graphql-playground';
 import {
   ApolloServerPluginLandingPageDisabled,
@@ -49,10 +48,9 @@ export function getAdminServer(
       { typeDefs: typeDefsAdmin, resolvers: adminResolvers },
     ]),
     plugins,
-    // Turning off the formatter for now as the web team needs to get the errors unmasked.
     // OSL-202 (https://getpocket.atlassian.net/browse/OSL-202) needs to get done in order
-    // to turn back on the formatter.
-    // formatError: errorHandler,
+    // to stop masking Apollo Errors.
+    formatError: errorHandler,
   });
 }
 

--- a/src/public/server.ts
+++ b/src/public/server.ts
@@ -1,8 +1,7 @@
 import { ApolloServer } from '@apollo/server';
 import { Server } from 'http';
 import { buildSubgraphSchema } from '@apollo/subgraph';
-// import { errorHandler, sentryPlugin } from '@pocket-tools/apollo-utils';
-import { sentryPlugin } from '@pocket-tools/apollo-utils';
+import { errorHandler, sentryPlugin } from '@pocket-tools/apollo-utils';
 import { ApolloServerPluginLandingPageGraphQLPlayground } from '@apollo/server-plugin-landing-page-graphql-playground';
 import {
   ApolloServerPluginLandingPageDisabled,
@@ -42,10 +41,9 @@ export function getPublicServer(
   return new ApolloServer<IPublicContext>({
     schema: buildSubgraphSchema([{ typeDefs: typeDefsPublic, resolvers }]),
     plugins,
-    // Turning off the formatter for now as the web team needs to get the errors unmasked.
     // OSL-202 (https://getpocket.atlassian.net/browse/OSL-202) needs to get done in order
-    // to turn back on the formatter.
-    // formatError: errorHandler,
+    // to stop masking Apollo Errors.
+    formatError: errorHandler,
   });
 }
 


### PR DESCRIPTION
## Goal

Due to the investigation on Apollo errors getting masked, it is determined it is a gateway level issue, so turning the apollo utils errorFormatter back on.

