### PR TITLE
OSL-97: Adding shareableLists query & resolver & integration tests

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -49,13 +49,17 @@ input CreateShareableListInput {
 }
 
 type Query {
-	lists: [ShareableList]
-
 	"""
 	Looks up and returns a Shareable List with a given external ID for a given user
 	(the user ID will be coming through with the headers)
 	"""
 	shareableList(externalId: String!): ShareableList
+
+	"""
+	Looks up and returns an array of Shareable Lists for a given user ID for a given user
+	(the user ID will be coming through with the headers)
+	"""
+	shareableLists: [ShareableList!]!
 }
 
 type Mutation {

--- a/src/database/queries.ts
+++ b/src/database/queries.ts
@@ -1,2 +1,3 @@
 // provide a single file to use for imports
 export { getShareableList } from './queries/ShareableList';
+export { getShareableLists } from './queries/ShareableList';

--- a/src/database/queries/ShareableList.ts
+++ b/src/database/queries/ShareableList.ts
@@ -53,18 +53,7 @@ export async function getShareableLists(
       moderationStatus: true,
       createdAt: true,
       updatedAt: true,
-      listItems: {
-        select: {
-          url: true,
-          title: true,
-          excerpt: true,
-          imageUrl: true,
-          authors: true,
-          sortOrder: true,
-          createdAt: true,
-          updatedAt: true,
-        },
-      },
+      listItems: true,
     },
   });
 }

--- a/src/database/queries/ShareableList.ts
+++ b/src/database/queries/ShareableList.ts
@@ -44,15 +44,7 @@ export async function getShareableLists(
       moderationStatus: ModerationStatus.VISIBLE,
     },
     orderBy: { updatedAt: 'desc' },
-    select: {
-      externalId: true,
-      slug: true,
-      title: true,
-      description: true,
-      status: true,
-      moderationStatus: true,
-      createdAt: true,
-      updatedAt: true,
+    include: {
       listItems: true,
     },
   });

--- a/src/database/queries/ShareableList.ts
+++ b/src/database/queries/ShareableList.ts
@@ -46,3 +46,44 @@ export async function getShareableList(
     },
   });
 }
+
+/**
+ * Retrieves all available shareable lists for a given userId from the datastore.
+ *
+ * @param db
+ * @param userId
+ */
+export async function getShareableLists(
+  db: PrismaClient,
+  userId: number | bigint
+): Promise<ShareableList[]> {
+  return db.list.findMany({
+    where: {
+      userId,
+      moderationStatus: ModerationStatus.VISIBLE,
+    },
+    orderBy: { updatedAt: 'desc' },
+    select: {
+      externalId: true,
+      slug: true,
+      title: true,
+      description: true,
+      status: true,
+      moderationStatus: true,
+      createdAt: true,
+      updatedAt: true,
+      listItems: {
+        select: {
+          url: true,
+          title: true,
+          excerpt: true,
+          imageUrl: true,
+          authors: true,
+          sortOrder: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      },
+    },
+  });
+}

--- a/src/public/resolvers/fragments.gql.ts
+++ b/src/public/resolvers/fragments.gql.ts
@@ -1,0 +1,39 @@
+import { gql } from 'graphql-tag';
+
+/**
+ * This GraphQL fragment contains all the properties that must be available
+ * in the Pocket Graph for a Shareable List Item.
+ */
+export const ShareableListItemPublicProps = gql`
+  fragment ShareableListItemPublicProps on ShareableListItem {
+    url
+    title
+    excerpt
+    imageUrl
+    authors
+    sortOrder
+    createdAt
+    updatedAt
+  }
+`;
+
+/**
+ * This GraphQL fragment contains all the properties that must be available
+ * in the Pocket Graph for a Shareable List.
+ */
+export const ShareableListPublicProps = gql`
+  fragment ShareableListPublicProps on ShareableList {
+    externalId
+    title
+    description
+    slug
+    status
+    moderationStatus
+    createdAt
+    updatedAt
+    listItems {
+      ...ShareableListItemPublicProps
+    }
+  }
+  ${ShareableListItemPublicProps}
+`;

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -1,38 +1,10 @@
-import { faker } from '@faker-js/faker';
-import { getShareableList } from './queries/ShareableList';
+import { getShareableList, getShareableLists } from './queries/ShareableList';
 import { createShareableList } from './mutations/ShareableList';
-
-// dummy data -- this is temporary
-const listData = [];
-let singleList;
-for (let i = 0; i < 5; i++) {
-  singleList = {};
-  singleList['externalId'] = faker.datatype.uuid();
-  singleList['slug'] = faker.lorem.slug();
-  singleList['title'] = faker.random.words(5);
-  singleList['description'] = faker.lorem.sentences(2);
-  singleList['status'] = 'PUBLIC';
-  singleList['moderationStatus'] = 'VISIBLE';
-  singleList['listItems'] = [
-    {
-      externalId: faker.datatype.uuid(),
-      listId: i,
-      url: faker.internet.url(),
-      title: faker.random.words(2),
-      excerpt: faker.lorem.sentences(4),
-    },
-  ];
-  listData.push(singleList);
-}
-
-function lists(): any {
-  return listData;
-}
 
 export const resolvers = {
   Mutation: { createShareableList },
   Query: {
-    lists,
     shareableList: getShareableList,
+    shareableLists: getShareableLists,
   },
 };

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -198,34 +198,33 @@ describe('public queries: ShareableList', () => {
 
       // Expect the array length to contain 2 lists
       expect(result.body.data.shareableLists.length).to.equal(2);
-
-      // Verify the first List props in the aray
-      const list1 = result.body.data.shareableLists[0];
-      // these checks also ensure that the List array is ordered by updatedAt (desc)
-      // as the first element in the array is the most recently created List
-      expect(list1.title).to.equal(shareableList2.title);
-      expect(list1.slug).to.equal(shareableList2.slug);
-      expect(list1.description).to.equal(shareableList2.description);
-      expect(list1.status).to.equal(ListStatus.PRIVATE);
-      expect(list1.moderationStatus).to.equal(ModerationStatus.VISIBLE);
-      expect(list1.createdAt).not.to.be.empty;
-      expect(list1.updatedAt).not.to.be.empty;
-      expect(list1.externalId).not.to.be.empty;
-      // Empty list items array
-      expect(list1.listItems).to.have.lengthOf(0);
-
-      // Verify the second List props in the aray
-      const list2 = result.body.data.shareableLists[1];
-      expect(list2.title).to.equal(shareableList.title);
-      expect(list2.slug).to.equal(shareableList.slug);
-      expect(list2.description).to.equal(shareableList.description);
-      expect(list2.status).to.equal(ListStatus.PRIVATE);
-      expect(list2.moderationStatus).to.equal(ModerationStatus.VISIBLE);
-      expect(list1.createdAt).not.to.be.empty;
-      expect(list1.updatedAt).not.to.be.empty;
-      expect(list1.externalId).not.to.be.empty;
-      // Empty list items array
-      expect(list2.listItems).to.have.lengthOf(0);
+      // We also want to assert that the first list returned in the array is the most recently created
+      const listArray = [shareableList2, shareableList];
+      // Loop over both lists and check their values are as expected
+      for (let i = 0; i < listArray.length; i++) {
+        expect(result.body.data.shareableLists[i].title).to.equal(
+          listArray[i].title
+        );
+        expect(result.body.data.shareableLists[i].slug).to.equal(
+          listArray[i].slug
+        );
+        expect(result.body.data.shareableLists[i].description).to.equal(
+          listArray[i].description
+        );
+        expect(result.body.data.shareableLists[i].status).to.equal(
+          ListStatus.PRIVATE
+        );
+        expect(result.body.data.shareableLists[i].moderationStatus).to.equal(
+          ModerationStatus.VISIBLE
+        );
+        expect(result.body.data.shareableLists[i].createdAt).not.to.be.empty;
+        expect(result.body.data.shareableLists[i].updatedAt).not.to.be.empty;
+        expect(result.body.data.shareableLists[i].externalId).not.to.be.empty;
+        // Empty list items array
+        expect(result.body.data.shareableLists[i].listItems).to.have.lengthOf(
+          0
+        );
+      }
     });
 
     it('should return an array of lists with list items for a given userId', async () => {

--- a/src/public/resolvers/queries/ShareableList.ts
+++ b/src/public/resolvers/queries/ShareableList.ts
@@ -1,12 +1,15 @@
 import { NotFoundError } from '@pocket-tools/apollo-utils';
-import { getShareableList as dbGetShareableList } from '../../../database/queries';
+import {
+  getShareableList as dbGetShareableList,
+  getShareableLists as dbGetShareableLists,
+} from '../../../database/queries';
 import { ShareableList } from '../../../database/types';
 
 /**
  * Resolver for the public 'shareableList` query.
  *
  * @param parent
- * @param slug
+ * @param externalId
  * @param userId
  * @param db
  */
@@ -22,4 +25,19 @@ export async function getShareableList(
   }
 
   return list;
+}
+
+/**
+ * Retrieves all available shareable lists for a userId (passed thru the headers).
+ *
+ * @param parent
+ * @param userId
+ * @param db
+ */
+export async function getShareableLists(
+  parent,
+  _,
+  { userId, db }
+): Promise<ShareableList[]> {
+  return await dbGetShareableLists(db, userId);
 }

--- a/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/src/public/resolvers/queries/sample-queries.gql.ts
@@ -18,21 +18,3 @@ export const GET_SHAREABLE_LISTS = gql`
   }
   ${ShareableListPublicProps}
 `;
-
-export const GET_LISTS = gql`
-  query lists {
-    lists {
-      slug
-      title
-      description
-      status
-      moderationStatus
-      listItems {
-        url
-        imageUrl
-        title
-        excerpt
-      }
-    }
-  }
-`;

--- a/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/src/public/resolvers/queries/sample-queries.gql.ts
@@ -1,4 +1,5 @@
 import { gql } from 'graphql-tag';
+import { ShareableListPublicProps } from '../fragments.gql';
 
 export const GET_SHAREABLE_LIST = gql`
   query shareableList($externalId: String!) {
@@ -23,6 +24,15 @@ export const GET_SHAREABLE_LIST = gql`
       }
     }
   }
+`;
+
+export const GET_SHAREABLE_LISTS = gql`
+  query shareableLists {
+    shareableLists {
+      ...ShareableListPublicProps
+    }
+  }
+  ${ShareableListPublicProps}
 `;
 
 export const GET_LISTS = gql`


### PR DESCRIPTION
## Goal

* Added the `shareableLists` query to the public schema (returns an array of Lists for a `userId` passed via the headers). This will unblock the web team and allow them to retrieve an array of Lists for a user.
    * Implemented the db query and `orderBy: { updatedAt: 'desc' }`
    * Implemented the resolver
    * Added integration tests
* Removed the temporary `lists` query and dummy data


## Todos

- [x] deploy to dev
- [x] wait for OSL-102 to be merged to update branch

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-97](https://getpocket.atlassian.net/browse/OSL-97)