### PR TITLE
OSL-151: Adding deleteShareableListItem mutation, resolver & tests

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -49,21 +49,21 @@ input CreateShareableListInput {
 }
 
 input UpdateShareableListInput {
-    externalId: String!
-    title: String
-    description: String
-    status: ShareableListStatus
+	externalId: String!
+	title: String
+	description: String
+	status: ShareableListStatus
 }
 
 type Query {
 	"""
-	Looks up and returns a Shareable List with a given external ID for a given user
+	Looks up and returns a Shareable List with a given external ID for a given user.
 	(the user ID will be coming through with the headers)
 	"""
 	shareableList(externalId: String!): ShareableList
 
 	"""
-	Looks up and returns an array of Shareable Lists for a given user ID for a given user
+	Looks up and returns an array of Shareable Lists for a given user ID for a given user.
 	(the user ID will be coming through with the headers)
 	"""
 	shareableLists: [ShareableList!]!
@@ -71,11 +71,15 @@ type Query {
 
 type Mutation {
 	"""
-	Creates a Shareable List
+	Creates a Shareable List.
 	"""
 	createShareableList(data: CreateShareableListInput!): ShareableList
-  """
-  Updates a Shareable List. This includes making it public.
-  """
-  updateShareableList(data: UpdateShareableListInput!): ShareableList!
+	"""
+	Updates a Shareable List. This includes making it public.
+	"""
+	updateShareableList(data: UpdateShareableListInput!): ShareableList!
+	"""
+	Deletes a Shareable List Item. HIDDEN Lists cannot have their items deleted.
+	"""
+	deleteShareableListItem(externalId: String!): ShareableListItem!
 }

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -32,7 +32,7 @@ type ShareableListItem {
 }
 
 type ShareableList {
-	externalId: String!
+	externalId: ID!
 	slug: String
 	title: String!
 	description: String
@@ -49,7 +49,7 @@ input CreateShareableListInput {
 }
 
 input UpdateShareableListInput {
-	externalId: String!
+	externalId: ID!
 	title: String
 	description: String
 	status: ShareableListStatus
@@ -60,7 +60,7 @@ type Query {
 	Looks up and returns a Shareable List with a given external ID for a given user.
 	(the user ID will be coming through with the headers)
 	"""
-	shareableList(externalId: String!): ShareableList
+	shareableList(externalId: ID!): ShareableList
 
 	"""
 	Looks up and returns an array of Shareable Lists for a given user ID for a given user.
@@ -81,5 +81,5 @@ type Mutation {
 	"""
 	Deletes a Shareable List Item. HIDDEN Lists cannot have their items deleted.
 	"""
-	deleteShareableListItem(externalId: String!): ShareableListItem!
+	deleteShareableListItem(externalId: ID!): ShareableListItem!
 }

--- a/src/database/mutations.ts
+++ b/src/database/mutations.ts
@@ -1,3 +1,6 @@
 // provide a single file to use for imports
-export { createShareableList } from './mutations/ShareableList';
-export { updateShareableList } from './mutations/ShareableList';
+export {
+  createShareableList,
+  updateShareableList,
+} from './mutations/ShareableList';
+export { deleteShareableListItem } from './mutations/ShareableListItem';

--- a/src/database/mutations/ShareableListItem.ts
+++ b/src/database/mutations/ShareableListItem.ts
@@ -1,0 +1,57 @@
+import {
+  NotFoundError,
+  ForbiddenError,
+  UserInputError,
+} from '@pocket-tools/apollo-utils';
+import { ACCESS_DENIED_ERROR } from '../../shared/constants';
+import { PrismaClient } from '@prisma/client';
+import { ShareableListItem } from '../types';
+
+/**
+ * This mutation deletes a shareable list item. Lists that are HIDDEN cannot have their items deleted.
+ *
+ * @param db
+ * @param externalId
+ * @param userId
+ */
+export async function deleteShareableListItem(
+  db: PrismaClient,
+  externalId: string,
+  userId: number | bigint
+): Promise<ShareableListItem> {
+  if (!externalId) {
+    throw new UserInputError('externalId must be provided.');
+  }
+  // retrieve the existing ListItem before it is deleted
+  const listItem = await db.listItem.findFirst({
+    where: {
+      externalId,
+    },
+  });
+
+  // Check if the ListItem was found
+  if (!listItem) {
+    throw new NotFoundError('A list item by that ID could not be found');
+  }
+  // Retrieve the parent List of the ListItem to be deleted
+  const list = await db.list.findFirst({
+    where: {
+      userId,
+      listItems: {
+        some: { externalId: { in: [externalId] } },
+      },
+    },
+  });
+
+  // Check first the List moderation status. If HIDDEN, do not allow delete
+  if (list.moderationStatus == 'HIDDEN') {
+    throw new ForbiddenError(ACCESS_DENIED_ERROR);
+  }
+  // delete ListItem
+  await db.listItem.delete({
+    where: {
+      externalId: listItem.externalId,
+    },
+  });
+  return listItem;
+}

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -3,11 +3,16 @@ import {
   createShareableList,
   updateShareableList,
 } from './mutations/ShareableList';
+import { deleteShareableListItem } from './mutations/ShareableListItem';
 import { shareableListFieldResolvers } from './fieldResolvers';
 
 export const resolvers = {
   ShareableList: shareableListFieldResolvers,
-  Mutation: { createShareableList, updateShareableList },
+  Mutation: {
+    createShareableList,
+    updateShareableList,
+    deleteShareableListItem,
+  },
   Query: {
     shareableList: getShareableList,
     shareableLists: getShareableLists,

--- a/src/public/resolvers/mutations/ShareableList.ts
+++ b/src/public/resolvers/mutations/ShareableList.ts
@@ -8,22 +8,7 @@ import {
   updateShareableList as dbUpdateShareableList,
 } from '../../../database/mutations';
 import { IPublicContext } from '../../context';
-
-/**
- * Executes a mutation, catches exceptions and records to sentry and console
- * @param context
- * @param data
- * @param callback
- */
-export async function executeMutation<T, U>(
-  context: IPublicContext,
-  data: T,
-  callback: (db, data: T, userId?: number | bigint) => Promise<U>
-): Promise<U> {
-  const { db, userId } = context;
-
-  return await callback(db, data, userId);
-}
+import { executeMutation } from './utils';
 
 /**
  * @param parent

--- a/src/public/resolvers/mutations/ShareableListItem.integration.ts
+++ b/src/public/resolvers/mutations/ShareableListItem.integration.ts
@@ -1,0 +1,161 @@
+import { expect } from 'chai';
+import { print } from 'graphql';
+import request from 'supertest';
+import { ApolloServer } from '@apollo/server';
+import { List, ListItem, ModerationStatus, PrismaClient } from '@prisma/client';
+import { startServer } from '../../../express';
+import { IPublicContext } from '../../context';
+import { client } from '../../../database/client';
+import { DELETE_SHAREABLE_LIST_ITEM } from './sample-mutations.gql';
+import {
+  clearDb,
+  createShareableListHelper,
+  createShareableListItemHelper,
+} from '../../../test/helpers';
+import { ACCESS_DENIED_ERROR } from '../../../shared/constants';
+
+describe('public mutations: ShareableListItem', () => {
+  let app: Express.Application;
+  let server: ApolloServer<IPublicContext>;
+  let graphQLUrl: string;
+  let db: PrismaClient;
+  let shareableList: List;
+  let listItem1: ListItem;
+
+  const headers = {
+    userId: '12345',
+  };
+
+  beforeAll(async () => {
+    // port 0 tells express to dynamically assign an available port
+    ({
+      app,
+      publicServer: server,
+      publicUrl: graphQLUrl,
+    } = await startServer(0));
+    db = client();
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+    await server.stop();
+  });
+
+  beforeEach(async () => {
+    await clearDb(db);
+    // Create a VISIBLE List
+    shareableList = await createShareableListHelper(db, {
+      userId: parseInt(headers.userId),
+      title: 'Simon Le Bon List',
+    });
+    // Create a ListItem
+    listItem1 = await createShareableListItemHelper(db, {
+      list: shareableList,
+    });
+  });
+
+  describe('deleteShareableListItem', () => {
+    it('should not delete a list item if no externalId is passed', async () => {
+      // Run the mutation with no externalId passed
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(DELETE_SHAREABLE_LIST_ITEM),
+        });
+      expect(result.body.data).not.to.exist;
+      expect(result.body.errors.length).to.equal(1);
+      expect(result.body.errors[0].extensions.code).to.equal('BAD_USER_INPUT');
+      expect(result.body.errors[0].message).to.equal(
+        'Variable "$externalId" of required type "String!" was not provided.'
+      );
+    });
+
+    it('should not delete a list item without userId in header', async () => {
+      // Run the mutation with no userId in the header
+      const result = await request(app)
+        .post(graphQLUrl)
+        .send({
+          query: print(DELETE_SHAREABLE_LIST_ITEM),
+          variables: { externalId: listItem1.externalId },
+        });
+      expect(result.body.data).not.to.exist;
+      expect(result.body.errors.length).to.equal(1);
+      expect(result.body.errors[0].extensions.code).to.equal('FORBIDDEN');
+      expect(result.body.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+    });
+
+    it('should not delete a list item if no list item was found', async () => {
+      // Run the mutation with a non existing externalId
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(DELETE_SHAREABLE_LIST_ITEM),
+          variables: { externalId: 'non-existing-uuid' },
+        });
+      expect(result.body.data).not.to.exist;
+      expect(result.body.errors.length).to.equal(1);
+      expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
+      expect(result.body.errors[0].message).to.equal(
+        'Error - Not Found: A list item by that ID could not be found'
+      );
+    });
+
+    it('should not delete a list item if parent list is hidden', async () => {
+      // Create a HIDDEN List
+      const hiddenShareableList = await createShareableListHelper(db, {
+        userId: parseInt(headers.userId),
+        title: 'Simon Le Bon List',
+        moderationStatus: ModerationStatus.HIDDEN,
+      });
+      // Create an item for the hidden list
+      const listItem3 = await createShareableListItemHelper(db, {
+        list: hiddenShareableList,
+      });
+      // Run the mutation
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(DELETE_SHAREABLE_LIST_ITEM),
+          variables: { externalId: listItem3.externalId },
+        });
+      expect(result.body.data).not.to.exist;
+      expect(result.body.errors.length).to.equal(1);
+      expect(result.body.errors[0].extensions.code).to.equal('FORBIDDEN');
+      expect(result.body.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+    });
+
+    it('should successfully delete a list item', async () => {
+      // Run the mutation
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(DELETE_SHAREABLE_LIST_ITEM),
+          variables: { externalId: listItem1.externalId },
+        });
+      console.log(result.body);
+      expect(result.body.data.deleteShareableListItem).to.exist;
+      expect(result.body.data.deleteShareableListItem.title).to.equal(
+        listItem1.title
+      );
+      // Assert that the item is not present in the db anymore
+      // by trying to delete the same item
+      const result2 = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(DELETE_SHAREABLE_LIST_ITEM),
+          variables: { externalId: listItem1.externalId },
+        });
+      expect(result2.body.data).not.to.exist;
+      expect(result2.body.errors.length).to.equal(1);
+      expect(result2.body.errors[0].extensions.code).to.equal('NOT_FOUND');
+      expect(result2.body.errors[0].message).to.equal(
+        'Error - Not Found: A list item by that ID could not be found'
+      );
+    });
+  });
+});

--- a/src/public/resolvers/mutations/ShareableListItem.ts
+++ b/src/public/resolvers/mutations/ShareableListItem.ts
@@ -1,0 +1,21 @@
+import { ShareableListItem } from '../../../database/types';
+import { deleteShareableListItem as dbDeleteShareableListItem } from '../../../database/mutations';
+import { IPublicContext } from '../../context';
+import { executeMutation } from './utils';
+
+/**
+ * @param parent
+ * @param data
+ * @param context
+ */
+export async function deleteShareableListItem(
+  parent,
+  { externalId },
+  context: IPublicContext
+): Promise<ShareableListItem> {
+  return await executeMutation<string, ShareableListItem>(
+    context,
+    externalId,
+    dbDeleteShareableListItem
+  );
+}

--- a/src/public/resolvers/mutations/sample-mutations.gql.ts
+++ b/src/public/resolvers/mutations/sample-mutations.gql.ts
@@ -1,5 +1,8 @@
 import { gql } from 'graphql-tag';
-import { ShareableListPublicProps } from '../fragments.gql';
+import {
+  ShareableListPublicProps,
+  ShareableListItemPublicProps,
+} from '../fragments.gql';
 
 export const CREATE_SHAREABLE_LIST = gql`
   mutation createShareableList($data: CreateShareableListInput!) {
@@ -17,4 +20,13 @@ export const UPDATE_SHAREABLE_LIST = gql`
     }
   }
   ${ShareableListPublicProps}
+`;
+
+export const DELETE_SHAREABLE_LIST_ITEM = gql`
+  mutation deleteShareableListItem($externalId: String!) {
+    deleteShareableListItem(externalId: $externalId) {
+      ...ShareableListItemPublicProps
+    }
+  }
+  ${ShareableListItemPublicProps}
 `;

--- a/src/public/resolvers/mutations/sample-mutations.gql.ts
+++ b/src/public/resolvers/mutations/sample-mutations.gql.ts
@@ -23,7 +23,7 @@ export const UPDATE_SHAREABLE_LIST = gql`
 `;
 
 export const DELETE_SHAREABLE_LIST_ITEM = gql`
-  mutation deleteShareableListItem($externalId: String!) {
+  mutation deleteShareableListItem($externalId: ID!) {
     deleteShareableListItem(externalId: $externalId) {
       ...ShareableListItemPublicProps
     }

--- a/src/public/resolvers/mutations/utils.ts
+++ b/src/public/resolvers/mutations/utils.ts
@@ -1,0 +1,17 @@
+import { IPublicContext } from '../../context';
+
+/**
+ * Executes a mutation, catches exceptions and records to sentry and console
+ * @param context
+ * @param data
+ * @param callback
+ */
+export async function executeMutation<T, U>(
+  context: IPublicContext,
+  data: T,
+  callback: (db, data: T, userId?: number | bigint) => Promise<U>
+): Promise<U> {
+  const { db, userId } = context;
+
+  return await callback(db, data, userId);
+}

--- a/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/src/public/resolvers/queries/sample-queries.gql.ts
@@ -2,7 +2,7 @@ import { gql } from 'graphql-tag';
 import { ShareableListPublicProps } from '../fragments.gql';
 
 export const GET_SHAREABLE_LIST = gql`
-  query shareableList($externalId: String!) {
+  query shareableList($externalId: ID!) {
     shareableList(externalId: $externalId) {
       ...ShareableListPublicProps
     }

--- a/src/test/helpers/createShareableListHelper.ts
+++ b/src/test/helpers/createShareableListHelper.ts
@@ -1,10 +1,11 @@
-import { List, PrismaClient } from '@prisma/client';
+import { List, ModerationStatus, PrismaClient } from '@prisma/client';
 import { faker } from '@faker-js/faker';
 
 interface ListHelperInput {
   userId: number | bigint;
   title: string;
   description?: string;
+  moderationStatus?: ModerationStatus;
 }
 
 /**
@@ -23,6 +24,7 @@ export async function createShareableListHelper(
     userId: data.userId ?? faker.datatype.number(),
     title: listTitle,
     description: data.description ?? faker.lorem.sentences(2),
+    moderationStatus: data.moderationStatus ?? ModerationStatus.VISIBLE,
   };
 
   return await prisma.list.create({


### PR DESCRIPTION
## Goal

* Added `deleteShareableListItem` mutation to public schema along with the resolver and tests
    * A `ListItem` cannot be deleted if its parent `List` `moderationStatus` = `HIDDEN`

## Todos

- [ ] deploy to dev


## Tickets

- [https://getpocket.atlassian.net/browse/OSL-151](https://getpocket.atlassian.net/browse/OSL-151)

