### PR TITLE
feat(mutation): [OSL-112] Add deleteShareableList mutation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
   provider      = "prisma-client-js"
   binaryTargets = ["native", "debian-openssl-1.1.x"]
+  previewFeatures = ["extendedWhereUnique"]
 }
 
 datasource db {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider      = "prisma-client-js"
   binaryTargets = ["native", "debian-openssl-1.1.x"]
-  previewFeatures = ["extendedWhereUnique"]
 }
 
 datasource db {

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -77,7 +77,7 @@ type Mutation {
 	"""
 	Deletes a Shareable List
 	"""
-	deleteShareableList(externalId: String!): String
+	deleteShareableList(externalId: ID!): ShareableList!
 	"""
 	Updates a Shareable List. This includes making it public.
 	"""

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -82,4 +82,8 @@ type Mutation {
 	Deletes a Shareable List Item. HIDDEN Lists cannot have their items deleted.
 	"""
 	deleteShareableListItem(externalId: ID!): ShareableListItem!
+	"""
+	Deletes a Shareable List
+	"""
+	deleteShareableList(externalId: String!): String
 }

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -86,5 +86,4 @@ type Mutation {
 	Deletes a Shareable List Item. HIDDEN Lists cannot have their items deleted.
 	"""
 	deleteShareableListItem(externalId: ID!): ShareableListItem!
-
 }

--- a/src/database/mutations.ts
+++ b/src/database/mutations.ts
@@ -1,6 +1,7 @@
 // provide a single file to use for imports
 export {
-  createShareableList,
+  createShareableList, 
+  deleteShareableList,
   updateShareableList,
 } from './mutations/ShareableList';
 export { deleteShareableListItem } from './mutations/ShareableListItem';

--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -107,7 +107,20 @@ export async function deleteShareableList(
   db: PrismaClient,
   externalId: string,
   userId: number | bigint 
-): Promise<String> {
+): Promise<ShareableList> {
+  const deleteList = await db.list.findUnique({
+    where: { externalId: externalId } ,
+    include: { listItems: true },
+  });
+  if (deleteList === null) {
+    throw new NotFoundError(`List ${externalId} is not available`);
+  } else if (deleteList.userId !== BigInt(userId)) { 
+    // local convention is to 404 when a normal user doesn't have resource ownership
+    throw new NotFoundError(`List ${externalId} is not accessible`);
+  }
+  return deleteList;
+  /*
+  
   // Note for PR : input is unsanitized
   
   // Since we 404 both in the case where the list doesn't exist, and in the case 
@@ -129,5 +142,6 @@ export async function deleteShareableList(
   
   console.log(deletedList);
   return deletedList.externalId;
+  */
 }
 

--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -1,6 +1,7 @@
 import { NotFoundError, UserInputError } from '@pocket-tools/apollo-utils';
 import { ListStatus, PrismaClient } from '@prisma/client';
 import slugify from 'slugify';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime';
 import {
   CreateShareableListInput,
   ShareableList,
@@ -8,6 +9,8 @@ import {
 } from '../types';
 import { getShareableList } from '../queries';
 import config from '../../config';
+
+const PRISMA_RECORD_NOT_FOUND = "P2025";
 
 /**
  * This mutation creates a shareable list, and _only_ a shareable list
@@ -89,4 +92,40 @@ export async function updateShareableList(
       listItems: true,
     },
   });
+}
+
+/**
+ * This method deletes a shareable list. if the owner of the list 
+ * represented by externalId matches the owner of the list. 
+ * 
+ * @param db
+ * @param externalId
+ * @param userId
+ */
+export async function deleteShareableList(
+  db: PrismaClient,
+  externalId: string,
+  userId: number | bigint 
+): Promise<String> {
+  // Note for PR : input is unsanitized
+  
+  // Since we 404 both in the case where the list doesn't exist, and in the case 
+  // where the owner is not the calling user, we can save a query by running 
+  // a delete using the [unique] externalId and adding the userId as a query constraint.
+  // This will most likely get replaced by a soft delete in a future revision anyway :) 
+    const deletedList = await db.list.delete({
+      where: { externalId: externalId, userId: userId },
+    }).catch((error) => {
+      // According to the Prisma docs, this should be a typed error 
+      // of type PrismaClientKnownRequestError, with a code, but it doesn't 
+      // come through typed
+      if (error.code === PRISMA_RECORD_NOT_FOUND) {
+        throw new NotFoundError(`List ${externalId} is not available`);
+      } else {
+        throw(error);
+      }
+    });
+  
+  console.log(deletedList);
+  return deletedList.externalId;
 }

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -1,10 +1,10 @@
 import { getShareableList, getShareableLists } from './queries/ShareableList';
-import { 
+import {
   createShareableList,
   deleteShareableList,
   updateShareableList,
 } from './mutations/ShareableList';
-import { deleteShareableListItem } from './mutations/ShareableListItem'
+import { deleteShareableListItem } from './mutations/ShareableListItem';
 
 import { shareableListFieldResolvers } from './fieldResolvers';
 

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -1,15 +1,18 @@
 import { getShareableList, getShareableLists } from './queries/ShareableList';
-import {
+import { 
   createShareableList,
+  deleteShareableList,
   updateShareableList,
 } from './mutations/ShareableList';
-import { deleteShareableListItem } from './mutations/ShareableListItem';
+import { deleteShareableListItem } from './mutations/ShareableListItem'
+
 import { shareableListFieldResolvers } from './fieldResolvers';
 
 export const resolvers = {
   ShareableList: shareableListFieldResolvers,
   Mutation: {
     createShareableList,
+    deleteShareableList,
     updateShareableList,
     deleteShareableListItem,
   },

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../database/types';
 import {
   CREATE_SHAREABLE_LIST,
+  DELETE_SHAREABLE_LIST,
   UPDATE_SHAREABLE_LIST,
 } from './sample-mutations.gql';
 import { clearDb, createShareableListHelper } from '../../../test/helpers';
@@ -182,6 +183,34 @@ describe('public mutations: ShareableList', () => {
       expect(result.body.data.createShareableList.moderationStatus).to.equal(
         ModerationStatus.VISIBLE
       );
+    });
+  });
+
+  describe('deleteShareableList', () => {
+    it('must not delete a list not owned by the current user', async() => {
+      const otherUserId = parseInt(headers.userId) + 1;
+      const otherUserList = await createShareableListHelper(db, {
+        title: `Someone else's list`,
+        userId: otherUserId,
+      });
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(DELETE_SHAREABLE_LIST),
+          variables: { externalId: otherUserList.externalId },
+        });
+      console.log(result.body.errors);
+      expect(result.body.errors.length).to.equal(1);
+      // expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
+    });
+
+    it('cannot delete a list that does not exist', async() => {
+
+    });
+
+    it('will delete a list created by the current user', async() => {
+
     });
   });
 
@@ -424,3 +453,5 @@ describe('public mutations: ShareableList', () => {
     });
   });
 });
+
+

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -202,7 +202,7 @@ describe('public mutations: ShareableList', () => {
         });
       expect(result.body.data).to.be.null;
       expect(result.body.errors.length).to.equal(1);
-      expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
+      expect(result.body.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
 
     it('cannot delete a list that does not exist', async () => {

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -187,7 +187,7 @@ describe('public mutations: ShareableList', () => {
   });
 
   describe('deleteShareableList', () => {
-    it('must not delete a list not owned by the current user', async() => {
+    it('must not delete a list not owned by the current user', async () => {
       const otherUserId = parseInt(headers.userId) + 1;
       const otherUserList = await createShareableListHelper(db, {
         title: `Someone else's list`,
@@ -205,8 +205,8 @@ describe('public mutations: ShareableList', () => {
       expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
     });
 
-    it('cannot delete a list that does not exist', async() => {
-      const dummyId = "1234567-1234-1234-1234-123456789012";
+    it('cannot delete a list that does not exist', async () => {
+      const dummyId = '1234567-1234-1234-1234-123456789012';
       const result = await request(app)
         .post(graphQLUrl)
         .set(headers)
@@ -219,7 +219,7 @@ describe('public mutations: ShareableList', () => {
       expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
     });
 
-    it('will delete a list created by the current user', async() => {
+    it('will delete a list created by the current user', async () => {
       const theList = await createShareableListHelper(db, {
         title: `A list to be deleted`,
         userId: BigInt(headers.userId),
@@ -231,11 +231,15 @@ describe('public mutations: ShareableList', () => {
           query: print(DELETE_SHAREABLE_LIST),
           variables: { externalId: theList.externalId },
         });
-      
+
       expect(result.body.errors).to.be.undefined;
       expect(result.body.data.deleteShareableList).to.exist;
-      expect(result.body.data.deleteShareableList.externalId).to.equal(theList.externalId);
-      expect(result.body.data.deleteShareableList.title).to.equal(theList.title);
+      expect(result.body.data.deleteShareableList.externalId).to.equal(
+        theList.externalId
+      );
+      expect(result.body.data.deleteShareableList.title).to.equal(
+        theList.title
+      );
     });
   });
 
@@ -478,5 +482,3 @@ describe('public mutations: ShareableList', () => {
     });
   });
 });
-
-

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -200,17 +200,42 @@ describe('public mutations: ShareableList', () => {
           query: print(DELETE_SHAREABLE_LIST),
           variables: { externalId: otherUserList.externalId },
         });
-      console.log(result.body.errors);
+      expect(result.body.data).to.be.null;
       expect(result.body.errors.length).to.equal(1);
-      // expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
+      expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
     });
 
     it('cannot delete a list that does not exist', async() => {
-
+      const dummyId = "1234567-1234-1234-1234-123456789012";
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(DELETE_SHAREABLE_LIST),
+          variables: { externalId: dummyId },
+        });
+      expect(result.body.data).to.be.null;
+      expect(result.body.errors.length).to.equal(1);
+      expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
     });
 
     it('will delete a list created by the current user', async() => {
-
+      const theList = await createShareableListHelper(db, {
+        title: `A list to be deleted`,
+        userId: BigInt(headers.userId),
+      });
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(DELETE_SHAREABLE_LIST),
+          variables: { externalId: theList.externalId },
+        });
+      
+      expect(result.body.errors).to.be.undefined;
+      expect(result.body.data.deleteShareableList).to.exist;
+      expect(result.body.data.deleteShareableList.externalId).to.equal(theList.externalId);
+      expect(result.body.data.deleteShareableList.title).to.equal(theList.title);
     });
   });
 

--- a/src/public/resolvers/mutations/ShareableList.ts
+++ b/src/public/resolvers/mutations/ShareableList.ts
@@ -3,8 +3,9 @@ import {
   ShareableList,
   UpdateShareableListInput,
 } from '../../../database/types';
-import {
+import { 
   createShareableList as dbCreateShareableList,
+  deleteShareableList as dbDeleteShareableList,
   updateShareableList as dbUpdateShareableList,
 } from '../../../database/mutations';
 import { IPublicContext } from '../../context';
@@ -44,5 +45,22 @@ export async function updateShareableList(
     context,
     data,
     dbUpdateShareableList
+  );
+}
+
+/**
+ * @param parent
+ * @param externalId
+ * @param context
+ */
+export async function deleteShareableList(
+  parent,
+  { externalId },
+  context: IPublicContext
+): Promise<String> {
+  return await executeMutation<String, String>(
+    context,
+    externalId,
+    dbDeleteShareableList
   );
 }

--- a/src/public/resolvers/mutations/ShareableList.ts
+++ b/src/public/resolvers/mutations/ShareableList.ts
@@ -57,8 +57,8 @@ export async function deleteShareableList(
   parent,
   { externalId },
   context: IPublicContext
-): Promise<String> {
-  return await executeMutation<String, String>(
+): Promise<ShareableList> {
+  return await executeMutation<String, ShareableList>(
     context,
     externalId,
     dbDeleteShareableList

--- a/src/public/resolvers/mutations/ShareableList.ts
+++ b/src/public/resolvers/mutations/ShareableList.ts
@@ -3,7 +3,7 @@ import {
   ShareableList,
   UpdateShareableListInput,
 } from '../../../database/types';
-import { 
+import {
   createShareableList as dbCreateShareableList,
   deleteShareableList as dbDeleteShareableList,
   updateShareableList as dbUpdateShareableList,
@@ -58,7 +58,7 @@ export async function deleteShareableList(
   { externalId },
   context: IPublicContext
 ): Promise<ShareableList> {
-  return await executeMutation<String, ShareableList>(
+  return await executeMutation<string, ShareableList>(
     context,
     externalId,
     dbDeleteShareableList

--- a/src/public/resolvers/mutations/sample-mutations.gql.ts
+++ b/src/public/resolvers/mutations/sample-mutations.gql.ts
@@ -23,7 +23,7 @@ export const UPDATE_SHAREABLE_LIST = gql`
 `;
 
 export const DELETE_SHAREABLE_LIST = gql`
-  mutation deleteShareableList($externalId: String!) {
+  mutation deleteShareableList($externalId: ID!) {
     deleteShareableList(externalId: $externalId) {
       ...ShareableListPublicProps
     }

--- a/src/public/resolvers/mutations/sample-mutations.gql.ts
+++ b/src/public/resolvers/mutations/sample-mutations.gql.ts
@@ -22,6 +22,15 @@ export const UPDATE_SHAREABLE_LIST = gql`
   ${ShareableListPublicProps}
 `;
 
+export const DELETE_SHAREABLE_LIST = gql`
+  mutation deleteShareableList($externalId: String!) {
+    deleteShareableList(externalId: $externalId) {
+      ...ShareableListPublicProps
+    }
+  }
+  ${ShareableListPublicProps}
+`;
+
 export const DELETE_SHAREABLE_LIST_ITEM = gql`
   mutation deleteShareableListItem($externalId: ID!) {
     deleteShareableListItem(externalId: $externalId) {


### PR DESCRIPTION
## Goal

Adding a delete API call for Shared Lists, and related tests.

## Todos

This PR implements the basic List delete. Deletes are currently "hard" I expect that these will need to become soft deletes when data retention policy is clear, and when opportune.

List Items will need to be deleted when a list is deleted (presumably) this is ticketed at [OSL-124](https://getpocket.atlassian.net/browse/OSL-214?atlOrigin=eyJpIjoiMzdlMTVmM2FhODlmNDIwMDliZDUzYzM2ZTgyYWE4MTkiLCJwIjoiamlyYS1zbGFjay1pbnQifQ) and will be address in a follow-on PR.

### Some Questions

- How are app metrics/observability handled? 
- How is input sanitization handled?

I didn't see any evidence of these in the codebase, so wondering where these are handled and how they work, to whatever extent they are materialized.

## Deployment

There should be no outstanding deployment issues here, there are no new migrations or secrets, etc.

## Tickets

[OSL-112 add deleteShareableList mutation](https://getpocket.atlassian.net/jira/software/c/projects/OSL/issues/OSL-112)

## Implementation Decisions

No major implementation decisions here. Deleting a list could be done in one query instead of two, but this depends on a prisma preview feature, and the implementation will change anyway (see todos)

[OSL-124]: https://getpocket.atlassian.net/browse/OSL-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ