### PR TITLE
OSL-153: Adding admin api schema and configuring CircleCI Apollo job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,22 +58,53 @@ jobs:
             # This allows the PATH changes to persist to the next `run` step
             echo 'export PATH=$HOME/.rover/bin:$PATH' >> $BASH_ENV
       - run:
-          name: check service
-          command: rover subgraph check pocket-client-api@current --schema ./schema-public.graphql --name=shareable-lists-api
+          name: build public schema
+          # We have to send one file for the federated schema which means we have to concat our shared schema
+          # to the public schema before pushing up to apollo studio (this happens in the next step)
+          command: cat schema-shared.graphql schema-public.graphql > schema-client-api.graphql
+      - run:
+          name: build admin schema
+          # We have to send one file for the federated schema which means we have to concat our shared schema
+          # to the admin schema before pushing up to apollo studio (this happens in the next step)
+          command: cat schema-shared.graphql schema-admin.graphql > schema-admin-api.graphql
+      - run:
+          name: check service - public api
+          command: rover subgraph check pocket-client-api@current --schema ./schema-client-api.graphql --name=shareable-lists-api
+      - run:
+          name: check service - admin api
+          # rover expects an APOLLO_KEY env var, which is set in circleci. however, there's a different key for admin-api,
+          # so we specifically override the APOLLO_KEY value here
+          command: |
+            export APOLLO_KEY=$ADMIN_APOLLO_KEY
+            rover subgraph check pocket-admin-api@current --schema ./schema-admin-api.graphql --name=shareable-lists-api
       - when:
           condition:
             equal: [main, << pipeline.git.branch >>]
           steps:
             - run:
-                name: push service to prod
-                command: rover subgraph publish pocket-client-api@current --schema ./schema-public.graphql --routing-url https://shareablelistsapi.readitlater.com/ --name=shareable-lists-api
+                name: push service to prod - public api
+                command: rover subgraph publish pocket-client-api@current --schema ./schema-client-api.graphql --routing-url https://shareablelistsapi.readitlater.com/ --name=shareable-lists-api
+            - run:
+                name: push service to prod - admin api
+                # rover expects an APOLLO_KEY env var, which is set in circleci. however, there's a different key for admin-api,
+                # so we specifically override the APOLLO_KEY value here
+                command: |
+                  export APOLLO_KEY=$ADMIN_APOLLO_KEY
+                  rover subgraph publish pocket-admin-api@current --schema ./schema-admin-api.graphql --routing-url https://shareablelistsapi.readitlater.com/admin --name=shareable-lists-api
       - when:
           condition:
             equal: [dev, << pipeline.git.branch >>]
           steps:
             - run:
-                name: push service to dev
-                command: rover subgraph publish pocket-client-api@development --schema ./schema-public.graphql --routing-url https://shareablelistsapi.getpocket.dev/ --name=shareable-lists-api
+                name: push service to dev - public api
+                command: rover subgraph publish pocket-client-api@development --schema ./schema-client-api.graphql --routing-url https://shareablelistsapi.getpocket.dev/ --name=shareable-lists-api
+            - run:
+                name: push service to dev - admin api
+                # rover expects an APOLLO_KEY env var, which is set in circleci. however, there's a different key for admin-api,
+                # so we specifically override the APOLLO_KEY value here
+                command: |
+                  export APOLLO_KEY=$ADMIN_APOLLO_KEY
+                  rover subgraph publish pocket-admin-api@development --schema ./schema-admin-api.graphql --routing-url https://shareablelistsapi.getpocket.dev/admin --name=shareable-lists-api
 
   build:
     docker:

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -1,3 +1,26 @@
-type ThisIsATest {
-    description: String
+"""
+ISOString scalar - all datetimes fields are Typescript Date objects on this server &
+returned as ISO-8601 encoded date strings (e.g. ISOString scalars) to GraphQL clients.
+See Section 5.6 of the RFC 3339 profile of the ISO 8601 standard: https://www.ietf.org/rfc/rfc3339.txt.
+"""
+scalar ISOString
+
+type ShareableList {
+  id: ID!
+  externalId: ID!
+  """
+  UserId is of Float type as GraphQL does not support BigInt.
+  This will ensure that all large int values are handled and will
+  be interpreted as Number type
+  """
+  userId: Float!
+  slug: String
+  title: String!
+  description: String
+  status: ShareableListStatus!
+  moderationStatus: ShareableListModerationStatus!
+  moderatedBy: String
+  moderationReason: String
+  createdAt: ISOString!
+  updatedAt: ISOString!
 }

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -10,16 +10,6 @@ A URL to a web page or image
 """
 scalar Url
 
-enum ShareableListStatus {
-	PRIVATE
-	PUBLIC
-}
-
-enum ShareableListModerationStatus {
-	VISIBLE
-	HIDDEN
-}
-
 type ShareableListItem {
 	url: Url
 	title: String

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -1,0 +1,9 @@
+enum ShareableListStatus {
+  PRIVATE
+  PUBLIC
+}
+
+enum ShareableListModerationStatus {
+  VISIBLE
+  HIDDEN
+}

--- a/src/typeDefs.ts
+++ b/src/typeDefs.ts
@@ -2,12 +2,20 @@ import path from 'path';
 import fs from 'fs';
 import { gql } from 'graphql-tag';
 
+const sharedSchema = fs
+  .readFileSync(path.join(__dirname, '..', 'schema-shared.graphql'))
+  .toString();
+
 export const typeDefsPublic = gql(
   fs
     .readFileSync(path.join(__dirname, '..', 'schema-public.graphql'))
     .toString()
+    .concat(sharedSchema)
 );
 
 export const typeDefsAdmin = gql(
-  fs.readFileSync(path.join(__dirname, '..', 'schema-admin.graphql')).toString()
+  fs
+    .readFileSync(path.join(__dirname, '..', 'schema-admin.graphql'))
+    .toString()
+    .concat(sharedSchema)
 );


### PR DESCRIPTION
## Goal

* Created admin api schema with `ShareableList` model
    * included fields `id`, `userId`, `moderatedBy`, `moderationReason`
    * removed `listItems` fields
* Created `schema-shared.graphql` and moved `ShareableListStatus` and `ShareableListModerationStatus` to the shared schema
* Updated the Apollo job in CircleCI to append shared schema to both graphs & check & publish the admin api schema

## Todos

- [ ] deploy to dev

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-153](https://getpocket.atlassian.net/browse/OSL-153)