### PR TITLE
feat(queries): [OSL-147, OSL-149] Add resolver for publicShareableList query with tests

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -56,6 +56,10 @@ input UpdateShareableListInput {
 }
 
 type Query {
+  """
+  Returns a publicly-shared Shareable List. Note: this query does not require user authentication.
+  """
+  publicShareableList(slug: String!): ShareableList
 	"""
 	Looks up and returns a Shareable List with a given external ID for a given user.
 	(the user ID will be coming through with the headers)

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -59,7 +59,7 @@ type Query {
   """
   Returns a publicly-shared Shareable List. Note: this query does not require user authentication.
   """
-  publicShareableList(slug: String!): ShareableList
+  publicShareableList(slug: String!, userId: Float!): ShareableList
 	"""
 	Looks up and returns a Shareable List with a given external ID for a given user.
 	(the user ID will be coming through with the headers)

--- a/src/database/queries.ts
+++ b/src/database/queries.ts
@@ -1,3 +1,4 @@
 // provide a single file to use for imports
+export { getPublicShareableList } from './queries/ShareableList';
 export { getShareableList } from './queries/ShareableList';
 export { getShareableLists } from './queries/ShareableList';

--- a/src/database/queries/ShareableList.ts
+++ b/src/database/queries/ShareableList.ts
@@ -14,14 +14,16 @@ export async function getPublicShareableList(
   userId: number | bigint,
   slug: string
 ): Promise<ShareableList> {
-  // Work out the value of the slug that is stored in the DB
-  const storedSlug = /
-
+  // Work out the value of the slug that is stored in the DB.
+  // Note that this is dependent on the implementation of the slug
+  // returned in `shareableListFieldResolvers`.
+  const matches = slug.match(/^(.+?)-[a-z\d]{8}$/i);
+  const storedSlug = matches[0];
 
   return db.list.findFirst({
     where: {
       userId,
-      slug,
+      slug: storedSlug,
       moderationStatus: ModerationStatus.VISIBLE,
     },
     include: {

--- a/src/database/queries/ShareableList.ts
+++ b/src/database/queries/ShareableList.ts
@@ -2,8 +2,36 @@ import { ModerationStatus, PrismaClient } from '@prisma/client';
 import { ShareableList } from '../types';
 
 /**
- * This is a public query, which is why we only return
- * a subset of ShareableList properties.
+ * This query returns a publicly viewable Shareable List, retrieved by its
+ * composite slug and user ID
+ *
+ * @param db
+ * @param userId
+ * @param slug
+ */
+export async function getPublicShareableList(
+  db: PrismaClient,
+  userId: number | bigint,
+  slug: string
+): Promise<ShareableList> {
+  // Work out the value of the slug that is stored in the DB
+  const storedSlug = /
+
+
+  return db.list.findFirst({
+    where: {
+      userId,
+      slug,
+      moderationStatus: ModerationStatus.VISIBLE,
+    },
+    include: {
+      listItems: true,
+    },
+  });
+}
+
+/**
+ * This query returns a shareable list created and owned by a Pocket user.
  *
  * @param db
  * @param userId

--- a/src/public/resolvers/queries/ShareableList.ts
+++ b/src/public/resolvers/queries/ShareableList.ts
@@ -1,12 +1,34 @@
 import { NotFoundError } from '@pocket-tools/apollo-utils';
 import {
+  getPublicShareableList as dbGetPublicShareableList,
   getShareableList as dbGetShareableList,
   getShareableLists as dbGetShareableLists,
 } from '../../../database/queries';
 import { ShareableList } from '../../../database/types';
 
 /**
- * Resolver for the public 'shareableList` query.
+ * Resolver for the `publicShareableList` query.
+ *
+ * @param parent
+ * @param slug
+ * @param db
+ */
+export async function getPublicShareableList(
+  parent,
+  { slug },
+  { db }
+): Promise<ShareableList> {
+  const list = await dbGetPublicShareableList(db, slug);
+
+  if (!list) {
+    throw new NotFoundError(slug);
+  }
+
+  return list;
+}
+
+/**
+ * Resolver for the `shareableList` query.
  *
  * @param parent
  * @param externalId

--- a/src/public/resolvers/queries/ShareableList.ts
+++ b/src/public/resolvers/queries/ShareableList.ts
@@ -8,17 +8,20 @@ import { ShareableList } from '../../../database/types';
 
 /**
  * Resolver for the `publicShareableList` query.
+ * Note the userId for this query comes from a request variable
+ * and not authentication headers.
  *
  * @param parent
  * @param slug
+ * @param userId
  * @param db
  */
 export async function getPublicShareableList(
   parent,
-  { slug },
+  { slug, userId },
   { db }
 ): Promise<ShareableList> {
-  const list = await dbGetPublicShareableList(db, slug);
+  const list = await dbGetPublicShareableList(db, userId, slug);
 
   if (!list) {
     throw new NotFoundError(slug);


### PR DESCRIPTION
## Goal

Provide a query to retrieve a list that has been shared publicly.

## Todos

- [x] Scaffold the basics
- [ ] Work out implementation details
- [ ] Add a 403 response rather than a 404 when a list was previously available but has now been taken down
- [ ] Refactor the context for the public graph (we don't need the logged-in user for this query)
- [ ] Add tests

## Tickets

https://getpocket.atlassian.net/browse/OSL-147