### PR TITLE
OSL-223: update deleteShareableListItem mutation

### DIFF
--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -10,11 +10,12 @@ import {
   ShareableList,
   UpdateShareableListInput,
 } from '../types';
-import { ACCESS_DENIED_ERROR } from '../../shared/constants';
+import {
+  ACCESS_DENIED_ERROR,
+  PRISMA_RECORD_NOT_FOUND,
+} from '../../shared/constants';
 import { getShareableList } from '../queries';
 import config from '../../config';
-
-const PRISMA_RECORD_NOT_FOUND = 'P2025';
 
 /**
  * This mutation creates a shareable list, and _only_ a shareable list

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -5,3 +5,5 @@ export const FULLACCESS = 'mozilliansorg_pocket_moderation_full';
 
 export const ACCESS_DENIED_ERROR =
   'You do not have access to perform this action.';
+
+export const PRISMA_RECORD_NOT_FOUND = 'P2025';


### PR DESCRIPTION
## Goal

As discussed in the previous[ PR](https://github.com/Pocket/shareable-lists-api/pull/51), we will update the existing `deleteShareableListItem` mutation to handle the rare yet possible Prisma `RECORD NOT FOUND` error.

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-223](https://getpocket.atlassian.net/browse/OSL-223)
