### PR TITLE
feat(mutation): [OSL-214] Delete list items when deleting a list

### DIFF
--- a/src/database/mutations/ShareableListItem.ts
+++ b/src/database/mutations/ShareableListItem.ts
@@ -121,3 +121,20 @@ export async function deleteShareableListItem(
     });
   return listItem;
 }
+
+/**
+ * Deletes all list items for a list.
+ * NB: userId is not checked here, as this method is called
+ * @param db
+ * @param listId
+ * @returns
+ */
+export async function deleteAllListItemsForList(
+  db: PrismaClient,
+  listId: bigint
+): Promise<number> {
+  const batchResult = await db.listItem.deleteMany({
+    where: { listId: listId },
+  });
+  return batchResult.count;
+}


### PR DESCRIPTION
## Goal

Delete list items when deleting a list.

This PR is pretty straightforward, but it did raise questions wrt Pocket's usage of foreign keys, commented inside.

## Reference

## Tickets

- Link to JIRA tickets

[OSL-214](https://getpocket.atlassian.net/browse/OSL-214)

## Implementation Decisions

Followed existing patterns. Would have preferred to not make list deletion subject to list item deletion but this is forced by key constraints at present. Also, we could arguably use to have integration tests directly against the mutations. There were not there at present, so I skipped this and tested on the public route where `deleteAllListItemsForList` is used instead. 


[OSL-214]: https://getpocket.atlassian.net/browse/OSL-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ