### PR TITLE
OSL-224: adding itemId as query input param for createShareableList mutation

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -78,7 +78,7 @@ type Mutation {
 	"""
 	createShareableList(data: CreateShareableListInput!): ShareableList
 	"""
-	Deletes a Shareable List
+	Deletes a Shareable List.
 	"""
 	deleteShareableList(externalId: ID!): ShareableList!
 	"""

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -11,7 +11,8 @@ A URL to a web page or image
 scalar Url
 
 type ShareableListItem {
-  externalId: ID!
+	externalId: ID!
+	itemId: Int
 	url: Url!
 	title: String
 	excerpt: String
@@ -47,13 +48,14 @@ input UpdateShareableListInput {
 }
 
 input CreateShareableListItemInput {
-  listExternalId: ID!
-  url: Url!
-  title: String
-  excerpt: String
-  imageUrl: Url
-  authors: String
-  sortOrder: Int!
+	listExternalId: ID!
+	itemId: Int
+	url: Url!
+	title: String
+	excerpt: String
+	imageUrl: Url
+	authors: String
+	sortOrder: Int!
 }
 
 type Query {
@@ -79,15 +81,17 @@ type Mutation {
 	Deletes a Shareable List
 	"""
 	deleteShareableList(externalId: ID!): ShareableList!
-  	"""
-  	Updates a Shareable List. This includes making it public.
-  	"""
-  	updateShareableList(data: UpdateShareableListInput!): ShareableList!
-  	"""
-  	Creates a Shareable List Item.
-  	"""
-  	createShareableListItem(data: CreateShareableListItemInput!): ShareableListItem
-  	"""
+	"""
+	Updates a Shareable List. This includes making it public.
+	"""
+	updateShareableList(data: UpdateShareableListInput!): ShareableList!
+	"""
+	Creates a Shareable List Item.
+	"""
+	createShareableListItem(
+		data: CreateShareableListItemInput!
+	): ShareableListItem
+	"""
 	Deletes a Shareable List Item. HIDDEN Lists cannot have their items deleted.
 	"""
 	deleteShareableListItem(externalId: ID!): ShareableListItem!

--- a/src/database/mutations/ShareableListItem.ts
+++ b/src/database/mutations/ShareableListItem.ts
@@ -56,6 +56,7 @@ export async function createShareableListItem(
   }
 
   const input = {
+    itemId: data.itemId,
     url: data.url,
     title: data.title ?? undefined,
     excerpt: data.excerpt ?? undefined,

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -4,10 +4,7 @@ import { List, ListItem, ListStatus } from '@prisma/client';
  * These are the properties of list items exposed on the public Pocket Graph -
  * props meant for the Admin Graph are omitted.
  */
-export type ShareableListItem = Omit<
-  ListItem,
-  'id' | 'externalId' | 'listId' | 'itemId'
->;
+export type ShareableListItem = Omit<ListItem, 'id' | 'externalId' | 'listId'>;
 
 /**
  * This is the shape of a shareable list object on the public Pocket Graph -
@@ -37,6 +34,7 @@ export type UpdateShareableListInput = {
 
 export type CreateShareableListItemInput = {
   listExternalId: string;
+  itemId?: number;
   url: string;
   title?: string;
   excerpt?: string;

--- a/src/public/resolvers/fragments.gql.ts
+++ b/src/public/resolvers/fragments.gql.ts
@@ -7,6 +7,7 @@ import { gql } from 'graphql-tag';
 export const ShareableListItemPublicProps = gql`
   fragment ShareableListItemPublicProps on ShareableListItem {
     externalId
+    itemId
     url
     title
     excerpt

--- a/src/public/resolvers/mutations/ShareableListItem.integration.ts
+++ b/src/public/resolvers/mutations/ShareableListItem.integration.ts
@@ -58,6 +58,7 @@ describe('public mutations: ShareableListItem', () => {
     it("should not create a new item for a list that doesn't exist", async () => {
       const data: CreateShareableListItemInput = {
         listExternalId: 'this-list-does-not-even-exist',
+        itemId: 1,
         url: 'https://getpocket.com/discover',
         sortOrder: 1,
       };
@@ -89,6 +90,7 @@ describe('public mutations: ShareableListItem', () => {
 
       const data: CreateShareableListItemInput = {
         listExternalId: hiddenList.externalId,
+        itemId: 1,
         url: 'https://getpocket.com/discover',
         sortOrder: 5,
       };
@@ -114,6 +116,7 @@ describe('public mutations: ShareableListItem', () => {
     it('should not create a list item in a list that belongs to another user', async () => {
       const data: CreateShareableListItemInput = {
         listExternalId: list.externalId,
+        itemId: 1,
         url: 'https://www.test.com/this-is-a-story',
         title: 'This Story Is Trying to Sneak In',
         sortOrder: 20,
@@ -140,6 +143,7 @@ describe('public mutations: ShareableListItem', () => {
     it('should create a new list item', async () => {
       const data: CreateShareableListItemInput = {
         listExternalId: list.externalId,
+        itemId: 1,
         url: 'https://www.test.com/this-is-a-story',
         title: 'A story is a story',
         excerpt: 'The best story ever told',
@@ -165,6 +169,7 @@ describe('public mutations: ShareableListItem', () => {
       // Assert that all props are returned
       const listItem = result.body.data.createShareableListItem;
       expect(listItem.externalId).not.to.be.empty;
+      expect(listItem.itemId).to.equal(1);
       expect(listItem.url).to.equal(data.url);
       expect(listItem.title).to.equal(data.title);
       expect(listItem.excerpt).to.equal(data.excerpt);
@@ -185,6 +190,7 @@ describe('public mutations: ShareableListItem', () => {
 
       const data: CreateShareableListItemInput = {
         listExternalId: list.externalId,
+        itemId: 1,
         url: 'https://www.test.com/duplicate-url',
         sortOrder: 5,
       };
@@ -223,6 +229,7 @@ describe('public mutations: ShareableListItem', () => {
 
       const data: CreateShareableListItemInput = {
         listExternalId: list.externalId,
+        itemId: 1,
         url: 'https://www.test.com/another-duplicate-url',
         title: 'A story is a story',
         excerpt: 'The best story ever told',
@@ -248,6 +255,7 @@ describe('public mutations: ShareableListItem', () => {
       // Assert that all props are returned
       const listItem = result.body.data.createShareableListItem;
       expect(listItem.externalId).not.to.be.empty;
+      expect(listItem.itemId).to.equal(1);
       expect(listItem.url).to.equal(data.url);
       expect(listItem.title).to.equal(data.title);
       expect(listItem.excerpt).to.equal(data.excerpt);

--- a/src/test/helpers/createShareableListItemHelper.ts
+++ b/src/test/helpers/createShareableListItemHelper.ts
@@ -4,6 +4,7 @@ import { faker } from '@faker-js/faker';
 interface ListItemHelperInput {
   // Provide the parent list Prisma object to be able to link the item to it
   list: List;
+  itemId?: number;
   url?: string;
   title?: string;
   excerpt?: string;
@@ -25,6 +26,7 @@ export async function createShareableListItemHelper(
 ): Promise<ListItem> {
   const input = {
     listId: data.list.id,
+    itemId: data.itemId ?? faker.datatype.number(),
     url: data.url ?? `${faker.internet.url()}/${faker.lorem.slug(5)}`,
     title: data.title ?? faker.random.words(5),
     excerpt: data.excerpt ?? faker.lorem.sentences(2),


### PR DESCRIPTION
## Goal

* Added `itemId` as optional input param for `createShareableList` mutation
* Added `itemId` to `ShareableListItem` type in public schema

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-224](https://getpocket.atlassian.net/browse/OSL-224)
