### PR TITLE
OSL-228: ensuring generated slug is unique

### DIFF
--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -518,7 +518,7 @@ describe('public mutations: ShareableList', () => {
         userId: BigInt(headers.userId),
       });
       // make list 2 PUBLIC
-      let dataList2 = {
+      const dataList2 = {
         externalId: secondList.externalId,
         status: ListStatus.PUBLIC,
       };


### PR DESCRIPTION
## Goal

* Ensuring generated slug for a list first time made public is unique. Adding a consecutive number to generated slug based on # of slugs containing list title in db.
* Added edge test case.

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-228](https://getpocket.atlassian.net/browse/OSL-228)