### PR TITLE
chore(query performance): [OSL-203] Add index[es] for default List and ListItem sorting

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,7 @@ model List {
   // *** Additional indexes and constraints ***
   @@unique([externalId])
   @@unique([userId, slug])
+  @@index([userId, moderationStatus, updatedAt])
 }
 
 model ListItem {


### PR DESCRIPTION
## Goal

Add the appropriate indexes so a users lists and list items will use indexes instead of filesort. This proved more "interesting" than expected. tl'dr: For Lists, the change was straightforward and functional, for ListItems the expected index does not work, ostensibly due to an interaction between the foreign key at `ListItem.listId` and the index.

### Lists

**Sample query**, output from Prisma query logging, with WHERE inserted manually: 

```
SELECT `shareablelists`.`List`.`id`, `shareablelists`.`List`.`externalId`, `shareablelists`.`List`.`userId`, `shareablelists`.`List`.`slug`, `shareablelists`.`List`.`title`, `shareablelists`.`List`.`description`, `shareablelists`.`List`.`status`, `shareablelists`.`List`.`moderationStatus`, `shareablelists`.`List`.`moderatedBy`, `shareablelists`.`List`.`moderationReason`, `shareablelists`.`List`.`createdAt`, `shareablelists`.`List`.`updatedAt` FROM `shareablelists`.`List` WHERE (`shareablelists`.`List`.`userId` = 12345 AND `shareablelists`.`List`.`moderationStatus` = 'VISIBLE') ORDER BY `shareablelists`.`List`.`updatedAt` DESC
```
**EXPLAIN** output, pre-index: 
```
+----+-------------+-------+------------+------+----------------------+----------------------+---------+-------+------+----------+----------------------------------------------------+
| id | select_type | table | partitions | type | possible_keys        | key                  | key_len | ref   | rows | filtered | Extra                                              |
+----+-------------+-------+------------+------+----------------------+----------------------+---------+-------+------+----------+----------------------------------------------------+
|  1 | SIMPLE      | List  | NULL       | ref  | List_userId_slug_key | List_userId_slug_key | 8       | const |    2 |    50.00 | Using index condition; Using where; Using filesort |
+----+-------------+-------+------------+------+----------------------+----------------------+---------+-------+------+----------+----------------------------------------------------+
1 row in set, 1 warning (0.01 sec)
```

**Create index** 

```
mysql> CREATE INDEX list_lists  on List (userId, moderationStatus, updatedAt);
Query OK, 0 rows affected (0.01 sec)
Records: 0  Duplicates: 0  Warnings: 0
```

Post-index output: 
```
+----+-------------+-------+------------+------+---------------------------------+------------+---------+-------------+------+----------+-------------+
| id | select_type | table | partitions | type | possible_keys                   | key        | key_len | ref         | rows | filtered | Extra       |
+----+-------------+-------+------------+------+---------------------------------+------------+---------+-------------+------+----------+-------------+
|  1 | SIMPLE      | List  | NULL       | ref  | List_userId_slug_key,list_lists | list_lists | 9       | const,const |    2 |    50.00 | Using where |
+----+-------------+-------+------------+------+---------------------------------+------------+---------+-------------+------+----------+-------------+
```



## Todos

- [ ] Outstanding todo
- [x] Completed todo

## Modifying Environment Variables

Omit this section if not applicable.

- [ ] Variables added to SSM
- [ ] Variables added to terraform environment config

Have you followed the guidelines in our Contributing document?

## Deployment

- [ ] Secrets?

## Reference

Documentation here:

- Link to docs

## Tickets

- Link to JIRA tickets

## Implementation Decisions
