### PR TITLE
feat(list items): [OSL-240] Add `publisher` field to List Items

### DIFF
--- a/prisma/migrations/20230228225212_add_publisher_to_list_items/migration.sql
+++ b/prisma/migrations/20230228225212_add_publisher_to_list_items/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `ListItem` ADD COLUMN `publisher` VARCHAR(300) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,6 +59,7 @@ model ListItem {
   title      String?  @db.VarChar(300)
   excerpt    String?  @db.Text
   imageUrl   String?  @db.VarChar(1000)
+  publisher  String?  @db.VarChar(300)
   authors    String?  @db.VarChar(1000)
   sortOrder  Int      @default(0)
   createdAt  DateTime @default(now()) @db.DateTime(0)

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -42,6 +42,10 @@ type ShareableListItem {
   """
 	imageUrl: Url
   """
+  The name of the publisher for this story. Supplied by the Parser.
+  """
+  publisher: String
+  """
   A comma-separated list of story authors. Supplied by the Parser.
   """
 	authors: String
@@ -137,6 +141,7 @@ input CreateShareableListItemInput {
 	title: String
 	excerpt: String
 	imageUrl: Url
+  publisher: String
 	authors: String
 	sortOrder: Int!
 }

--- a/src/database/mutations/ShareableListItem.ts
+++ b/src/database/mutations/ShareableListItem.ts
@@ -61,6 +61,7 @@ export async function createShareableListItem(
     title: data.title ?? undefined,
     excerpt: data.excerpt ?? undefined,
     imageUrl: data.imageUrl ?? undefined,
+    publisher: data.publisher ?? undefined,
     authors: data.authors ?? undefined,
     sortOrder: data.sortOrder,
     listId: list.id,

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -39,6 +39,7 @@ export type CreateShareableListItemInput = {
   title?: string;
   excerpt?: string;
   imageUrl?: string;
+  publisher?: string;
   authors?: string;
   sortOrder: number;
 };

--- a/src/public/resolvers/fragments.gql.ts
+++ b/src/public/resolvers/fragments.gql.ts
@@ -12,6 +12,7 @@ export const ShareableListItemPublicProps = gql`
     title
     excerpt
     imageUrl
+    publisher
     authors
     sortOrder
     createdAt

--- a/src/public/resolvers/mutations/ShareableListItem.integration.ts
+++ b/src/public/resolvers/mutations/ShareableListItem.integration.ts
@@ -148,6 +148,7 @@ describe('public mutations: ShareableListItem', () => {
         title: 'A story is a story',
         excerpt: 'The best story ever told',
         imageUrl: 'https://www.test.com/thumbnail.jpg',
+        publisher: 'The London Times',
         authors: 'Charles Dickens, Mark Twain',
         sortOrder: 10,
       };
@@ -174,6 +175,7 @@ describe('public mutations: ShareableListItem', () => {
       expect(listItem.title).to.equal(data.title);
       expect(listItem.excerpt).to.equal(data.excerpt);
       expect(listItem.imageUrl).to.equal(data.imageUrl);
+      expect(listItem.publisher).to.equal(data.publisher);
       expect(listItem.authors).to.equal(data.authors);
       expect(listItem.sortOrder).to.equal(data.sortOrder);
       expect(listItem.createdAt).not.to.be.empty;
@@ -234,6 +236,7 @@ describe('public mutations: ShareableListItem', () => {
         title: 'A story is a story',
         excerpt: 'The best story ever told',
         imageUrl: 'https://www.test.com/thumbnail.jpg',
+        publisher: 'The Hogwarts Express',
         authors: 'Charles Dickens, Mark Twain',
         sortOrder: 5,
       };
@@ -260,6 +263,7 @@ describe('public mutations: ShareableListItem', () => {
       expect(listItem.title).to.equal(data.title);
       expect(listItem.excerpt).to.equal(data.excerpt);
       expect(listItem.imageUrl).to.equal(data.imageUrl);
+      expect(listItem.publisher).to.equal(data.publisher);
       expect(listItem.authors).to.equal(data.authors);
       expect(listItem.sortOrder).to.equal(data.sortOrder);
       expect(listItem.createdAt).not.to.be.empty;

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -158,6 +158,7 @@ describe('public queries: ShareableList', () => {
         expect(listItem.title).not.to.be.empty;
         expect(listItem.excerpt).not.to.be.empty;
         expect(listItem.imageUrl).not.to.be.empty;
+        expect(listItem.publisher).not.to.be.empty;
         expect(listItem.authors).not.to.be.empty;
         expect(listItem.sortOrder).to.be.a('number');
         expect(listItem.createdAt).not.to.be.empty;
@@ -269,6 +270,7 @@ describe('public queries: ShareableList', () => {
         expect(listItem.title).not.to.be.empty;
         expect(listItem.excerpt).not.to.be.empty;
         expect(listItem.imageUrl).not.to.be.empty;
+        expect(listItem.publisher).not.to.be.empty;
         expect(listItem.authors).not.to.be.empty;
         expect(listItem.sortOrder).to.be.a('number');
         expect(listItem.createdAt).not.to.be.empty;
@@ -282,6 +284,7 @@ describe('public queries: ShareableList', () => {
         expect(listItem.title).not.to.be.empty;
         expect(listItem.excerpt).not.to.be.empty;
         expect(listItem.imageUrl).not.to.be.empty;
+        expect(listItem.publisher).not.to.be.empty;
         expect(listItem.authors).not.to.be.empty;
         expect(listItem.sortOrder).to.be.a('number');
         expect(listItem.createdAt).not.to.be.empty;

--- a/src/test/helpers/createShareableListItemHelper.ts
+++ b/src/test/helpers/createShareableListItemHelper.ts
@@ -9,6 +9,7 @@ interface ListItemHelperInput {
   title?: string;
   excerpt?: string;
   imageUrl?: string;
+  publisher?: string;
   authors?: string;
   sortOrder?: number;
 }
@@ -31,6 +32,7 @@ export async function createShareableListItemHelper(
     title: data.title ?? faker.random.words(5),
     excerpt: data.excerpt ?? faker.lorem.sentences(2),
     imageUrl: data.imageUrl ?? faker.image.cats(),
+    publisher: data.publisher ?? faker.company.name(),
     authors: data.authors ?? faker.name.fullName(),
     sortOrder: data.sortOrder ?? faker.datatype.number(),
   };


### PR DESCRIPTION
## Goal

Unblock the frontend as they need to save and display the `publisher` field on stories added to shareable lists.

- Added `publisher` field to Prisma schema.

- Added `publisher` to list of props on the `ShareableListItem` type in the public schema and to `CreateShareableListItemInput` to take in that value from the frontend when a new list item is created.

- Updated tests and test helpers to test for the presence of this field everywhere list items are manipulated or returned.


## Tickets

https://getpocket.atlassian.net/browse/OSL-240