### PR TITLE
OSL-245: enforce list title and description length during list update

### DIFF
--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -43,22 +43,11 @@ export async function createShareableList(
     );
   }
 
-  // check the length of the title (fail if title > 100 chars)
-  if (data.title.length > LIST_TITLE_MAX_CHARS) {
-    throw new UserInputError(
-      'List title must not be longer than 100 characters'
-    );
-  }
-
-  // check the length of the description (fail if description > 200 chars)
-  if (
-    data.description &&
-    data.description.length > LIST_DESCRIPTION_MAX_CHARS
-  ) {
-    throw new UserInputError(
-      'List description must not be longer than 200 characters'
-    );
-  }
+  // check list title and descipriotn length
+  shareableListTitleDescriptionValidation(
+    data.title,
+    data.description ? data.description : null
+  );
 
   return db.list.create({
     data: { ...data, userId },
@@ -100,6 +89,12 @@ export async function updateShareableList(
       );
     }
   }
+
+  // check list title and descipriotn length
+  shareableListTitleDescriptionValidation(
+    data.title ? data.title : null,
+    data.description ? data.description : null
+  );
 
   // If there is no slug and the list is being shared with the world,
   // let's generate a unique slug from the title. Once set, it will not be
@@ -200,4 +195,26 @@ export async function deleteShareableList(
       }
     });
   return deleteList;
+}
+
+/**
+ * helper function for validating list title and description length
+ */
+function shareableListTitleDescriptionValidation(
+  title: string,
+  description: string
+) {
+  // check the length of the title (fail if title > 100 chars)
+  if (title && title.length > LIST_TITLE_MAX_CHARS) {
+    throw new UserInputError(
+      'List title must not be longer than 100 characters'
+    );
+  }
+
+  // check the length of the description (fail if description > 200 chars)
+  if (description && description.length > LIST_DESCRIPTION_MAX_CHARS) {
+    throw new UserInputError(
+      'List description must not be longer than 200 characters'
+    );
+  }
 }

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -28,7 +28,11 @@ import {
   createShareableListItemHelper,
 } from '../../../test/helpers';
 import config from '../../../config';
-import { ACCESS_DENIED_ERROR } from '../../../shared/constants';
+import {
+  ACCESS_DENIED_ERROR,
+  LIST_TITLE_MAX_CHARS,
+  LIST_DESCRIPTION_MAX_CHARS,
+} from '../../../shared/constants';
 
 describe('public mutations: ShareableList', () => {
   let app: Express.Application;
@@ -137,7 +141,7 @@ describe('public mutations: ShareableList', () => {
 
     it('should not create List with a title of more than 100 chars', async () => {
       const data: CreateShareableListInput = {
-        title: faker.random.alpha(101),
+        title: faker.random.alpha(LIST_TITLE_MAX_CHARS + 1),
         description: faker.lorem.sentences(2),
       };
       const result = await request(app)
@@ -158,7 +162,7 @@ describe('public mutations: ShareableList', () => {
     it('should not create List with a description of more than 200 chars', async () => {
       const data: CreateShareableListInput = {
         title: `Katerina's List`,
-        description: faker.random.alpha(201),
+        description: faker.random.alpha(LIST_DESCRIPTION_MAX_CHARS + 1),
       };
       const result = await request(app)
         .post(graphQLUrl)
@@ -714,6 +718,60 @@ describe('public mutations: ShareableList', () => {
 
       // Is the slug unchanged? It should be!
       expect(updatedList.slug).to.equal(listWithSlugSet.slug);
+    });
+
+    it('should not update List with a title of more than 100 chars', async () => {
+      const data: UpdateShareableListInput = {
+        externalId: listToUpdate.externalId,
+        title: faker.random.alpha(LIST_TITLE_MAX_CHARS + 1),
+      };
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_SHAREABLE_LIST),
+          variables: { data },
+        });
+
+      // There should be nothing in results
+      expect(result.body.data).to.be.null;
+
+      // And a "Bad user input" error
+      expect(result.body).to.have.nested.property(
+        'errors[0].extensions.code',
+        'BAD_USER_INPUT'
+      );
+      expect(result.body.errors[0].message).to.equal(
+        `List title must not be longer than 100 characters`
+      );
+    });
+
+    it('should not update List with a description of more than 200 chars', async () => {
+      const data: UpdateShareableListInput = {
+        externalId: listToUpdate.externalId,
+        description: faker.random.alpha(LIST_DESCRIPTION_MAX_CHARS + 1),
+      };
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_SHAREABLE_LIST),
+          variables: { data },
+        });
+
+      // There should be nothing in results
+      expect(result.body.data).to.be.null;
+
+      // And a "Bad user input" error
+      expect(result.body).to.have.nested.property(
+        'errors[0].extensions.code',
+        'BAD_USER_INPUT'
+      );
+      expect(result.body.errors[0].message).to.equal(
+        `List description must not be longer than 200 characters`
+      );
     });
   });
 });


### PR DESCRIPTION
## Goal

Enforce list title and description length during list update. Updated tests.

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-245](https://getpocket.atlassian.net/browse/OSL-245)
