### PR TITLE
feat(sanitization): [OSL-227] add XSS protection to all public mutations

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,40 @@
+name: Shareable Lists API
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    name: Run Unit Tests
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 # v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # tag=v2.5.1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run the test suite
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "graphql-tag": "2.12.6",
         "graphql-upload": "15.0.2",
         "slugify": "1.6.5",
-        "uuid": "9.0.0"
+        "uuid": "9.0.0",
+        "xss": "^1.0.14"
       },
       "devDependencies": {
         "@faker-js/faker": "7.6.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "graphql-tag": "2.12.6",
     "graphql-upload": "15.0.2",
     "slugify": "1.6.5",
-    "uuid": "9.0.0"
+    "uuid": "9.0.0",
+    "xss": "^1.0.14"
   },
   "devDependencies": {
     "@faker-js/faker": "7.6.0",

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -91,7 +91,7 @@ describe('public mutations: ShareableList', () => {
     });
 
     it('should create a new List', async () => {
-      const title = faker.random.words(2);
+      const title = 'My list to share<script>alert("Hello World!")</script>';
       const data: CreateShareableListInput = {
         title: title,
         description: faker.lorem.sentences(2),
@@ -104,7 +104,9 @@ describe('public mutations: ShareableList', () => {
           variables: { data },
         });
       expect(result.body.data).to.exist;
-      expect(result.body.data.createShareableList.title).to.equal(title);
+      expect(result.body.data.createShareableList.title).to.equal(
+        'My list to share&lt;script&gt;alert("Hello World!")&lt;/script&gt;'
+      );
       expect(result.body.data.createShareableList.status).to.equal(
         ListStatus.PRIVATE
       );
@@ -329,7 +331,7 @@ describe('public mutations: ShareableList', () => {
       // Create a List
       listToUpdate = await createShareableListHelper(db, {
         userId: parseInt(headers.userId),
-        title: 'The Most Shareable List',
+        title: '<marquee>The Most Shareable List</marquee>',
       });
     });
 

--- a/src/public/resolvers/mutations/ShareableListItem.integration.ts
+++ b/src/public/resolvers/mutations/ShareableListItem.integration.ts
@@ -146,7 +146,7 @@ describe('public mutations: ShareableListItem', () => {
         itemId: 3789538749,
         url: 'https://www.test.com/this-is-a-story',
         title: 'A story is a story',
-        excerpt: 'The best story ever told',
+        excerpt: '<blink>The best story ever told</blink>',
         imageUrl: 'https://www.test.com/thumbnail.jpg',
         publisher: 'The London Times',
         authors: 'Charles Dickens, Mark Twain',
@@ -173,7 +173,9 @@ describe('public mutations: ShareableListItem', () => {
       expect(listItem.itemId).to.equal(3789538749);
       expect(listItem.url).to.equal(data.url);
       expect(listItem.title).to.equal(data.title);
-      expect(listItem.excerpt).to.equal(data.excerpt);
+      expect(listItem.excerpt).to.equal(
+        '&lt;blink&gt;The best story ever told&lt;/blink&gt;'
+      );
       expect(listItem.imageUrl).to.equal(data.imageUrl);
       expect(listItem.publisher).to.equal(data.publisher);
       expect(listItem.authors).to.equal(data.authors);

--- a/src/public/resolvers/mutations/utils.spec.ts
+++ b/src/public/resolvers/mutations/utils.spec.ts
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+import {
+  CreateShareableListInput,
+  CreateShareableListItemInput,
+} from '../../../database/types';
+import { sanitizeMutationInput } from './utils';
+
+describe('utility functions', () => {
+  describe('xssifyMutationInput', () => {
+    it('transforms strings in a mutation input object', () => {
+      const input: CreateShareableListInput = {
+        title: 'My <first> list',
+        description:
+          'Trying out this new Pocket feature<script>alert("!!!");</script>',
+      };
+
+      const safeInput = sanitizeMutationInput(input);
+
+      expect(safeInput.title).to.equal('My &lt;first&gt; list');
+      expect(safeInput.description).to.equal(
+        'Trying out this new Pocket feature&lt;script&gt;alert("!!!");&lt;/script&gt;'
+      );
+    });
+
+    it('returns numeric values as-is in a mutation input object', () => {
+      const input: CreateShareableListItemInput = {
+        listExternalId: '123-abc',
+        itemId: 456789,
+        url: 'https://www.test.com/story',
+        title: 'This is a test title',
+        excerpt: 'An excerpt sounds like a good thing to have',
+        imageUrl: 'https://www.test.com/<script>alert("hello world");</script>',
+        publisher: 'House of Random Penguins',
+        authors: 'Charles Dickens',
+        sortOrder: 10,
+      };
+
+      const safeInput = sanitizeMutationInput(input);
+
+      // dodgy strings are still escaped
+      expect(safeInput.imageUrl).to.equal(
+        'https://www.test.com/&lt;script&gt;alert("hello world");&lt;/script&gt;'
+      );
+
+      // numeric inputs go through as-is
+      expect(safeInput.itemId).to.equal(input.itemId);
+      expect(safeInput.sortOrder).to.equal(input.sortOrder);
+    });
+
+    it('sanitises strings', () => {
+      const externalId = 'uuid-something-1234<script>';
+
+      const safeInput = sanitizeMutationInput(externalId);
+
+      expect(safeInput).to.equal('uuid-something-1234&lt;script&gt;');
+    });
+
+    it('returns numeric values as-is', () => {
+      const sortOrder = 12345;
+
+      const safeInput = sanitizeMutationInput(sortOrder);
+
+      expect(safeInput).to.equal(sortOrder);
+    });
+  });
+});


### PR DESCRIPTION
## Goal

Sanitize all inputs! 

- Added the `xss` package.

- Added a new util function that sanitises inputs & added usage of it through the `executeMutation` function.

- Added a new GitHub workflow to run a check over unit tests.

- Modified existing integration tests to add checks for sanitization.

## Tickets

- https://getpocket.atlassian.net/browse/OSL-227
