### PR TITLE
refactor(errors): use NOT_FOUND in more places for security

### DIFF
--- a/src/admin/resolvers/queries/ShareableList.ts
+++ b/src/admin/resolvers/queries/ShareableList.ts
@@ -16,9 +16,11 @@ export async function searchShareableList(
   { externalId },
   { authenticatedUser, db }
 ): Promise<ShareableListComplete> {
+  // access denied if a user cannot access this admin tool
   if (!authenticatedUser.canRead) {
     throw new ForbiddenError(ACCESS_DENIED_ERROR);
   }
+
   const list = await dbSearchShareableList(db, externalId);
 
   if (!list) {

--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -1,8 +1,4 @@
-import {
-  ForbiddenError,
-  NotFoundError,
-  UserInputError,
-} from '@pocket-tools/apollo-utils';
+import { NotFoundError, UserInputError } from '@pocket-tools/apollo-utils';
 import { ListStatus, PrismaClient } from '@prisma/client';
 import slugify from 'slugify';
 import {
@@ -12,7 +8,6 @@ import {
 } from '../types';
 import { deleteAllListItemsForList } from './ShareableListItem';
 import {
-  ACCESS_DENIED_ERROR,
   LIST_TITLE_MAX_CHARS,
   LIST_DESCRIPTION_MAX_CHARS,
   PRISMA_RECORD_NOT_FOUND,
@@ -147,10 +142,12 @@ export async function deleteShareableList(
     where: { externalId: externalId },
     include: { listItems: true },
   });
-  if (deleteList === null) {
+
+  // if the list can't be found, or a user is trying to delete someone else's
+  // list, throw a not found error. (we don't need to let the malicious user
+  // know they found someone else's list id.)
+  if (deleteList === null || deleteList.userId !== BigInt(userId)) {
     throw new NotFoundError(`List ${externalId} cannot be found.`);
-  } else if (deleteList.userId !== BigInt(userId)) {
-    throw new ForbiddenError(ACCESS_DENIED_ERROR);
   }
   // This delete must occur before the list is actually deleted,
   // due to a foreign key constraint on ListIitems. We should remove this

--- a/src/public/context.ts
+++ b/src/public/context.ts
@@ -31,6 +31,7 @@ export class PublicContextManager implements IPublicContext {
     if (!userId) {
       throw new ForbiddenError(ACCESS_DENIED_ERROR);
     }
+
     return userId instanceof Array ? parseInt(userId[0]) : parseInt(userId);
   }
 }

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -249,7 +249,7 @@ describe('public mutations: ShareableList', () => {
         });
       expect(result.body.data).to.be.null;
       expect(result.body.errors.length).to.equal(1);
-      expect(result.body.errors[0].extensions.code).to.equal('FORBIDDEN');
+      expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
     });
 
     it('cannot delete a list that does not exist', async () => {

--- a/src/public/resolvers/mutations/ShareableListItem.integration.ts
+++ b/src/public/resolvers/mutations/ShareableListItem.integration.ts
@@ -307,8 +307,10 @@ describe('public mutations: ShareableListItem', () => {
         });
       expect(result.body.data).not.to.exist;
       expect(result.body.errors.length).to.equal(1);
-      expect(result.body.errors[0].extensions.code).to.equal('FORBIDDEN');
-      expect(result.body.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
+      expect(result.body.errors[0].message).to.equal(
+        'Error - Not Found: A list item by that ID could not be found'
+      );
     });
 
     it('should not delete a list item without userId in header', async () => {
@@ -363,8 +365,10 @@ describe('public mutations: ShareableListItem', () => {
         });
       expect(result.body.data).not.to.exist;
       expect(result.body.errors.length).to.equal(1);
-      expect(result.body.errors[0].extensions.code).to.equal('FORBIDDEN');
-      expect(result.body.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
+      expect(result.body.errors[0].message).to.equal(
+        'Error - Not Found: A list item by that ID could not be found'
+      );
     });
 
     it('should successfully delete a list item', async () => {


### PR DESCRIPTION
## Goal

use `NOT_FOUND` error to obfuscate potential malicious API request responses. (better if an attacker doesn't know that the list / list item ID they are maliciously trying to manipulate is valid.)

## Tickets

- https://getpocket.atlassian.net/browse/OSL-206
