### PR TITLE
feat(isPilotUser query): query to know if user is in pilot program

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -158,6 +158,11 @@ type Query {
   (the user ID will be coming through with the headers)
   """
   shareableLists: [ShareableList!]!
+
+  """
+  Determines if the userid passed in the headers has access to the pilot program.
+  """
+  isPilotUser: Boolean!
 }
 
 type Mutation {

--- a/src/database/queries.ts
+++ b/src/database/queries.ts
@@ -4,3 +4,5 @@ export {
   getShareableLists,
   searchShareableList,
 } from './queries/ShareableList';
+
+export { isPilotUser } from './queries/PilotUser';

--- a/src/database/queries/PilotUser.ts
+++ b/src/database/queries/PilotUser.ts
@@ -1,0 +1,18 @@
+import { PrismaClient } from '@prisma/client';
+
+/**
+ * Retrieves the number of users in the PilotUser table with the given userid
+ *
+ * @param db
+ * @param userId
+ */
+export function isPilotUser(
+  db: PrismaClient,
+  userId: number | bigint
+): Promise<number> {
+  return db.pilotUser.count({
+    where: {
+      userId,
+    },
+  });
+}

--- a/src/database/queries/ShareableList.ts
+++ b/src/database/queries/ShareableList.ts
@@ -10,7 +10,7 @@ import { ShareableList, ShareableListComplete } from '../types';
  * @param userId
  * @param externalId
  */
-export async function getShareableList(
+export function getShareableList(
   db: PrismaClient,
   userId: number | bigint,
   externalId: string
@@ -36,7 +36,7 @@ export async function getShareableList(
  * @param db
  * @param userId
  */
-export async function getShareableLists(
+export function getShareableLists(
   db: PrismaClient,
   userId: number | bigint
 ): Promise<ShareableList[]> {
@@ -59,7 +59,7 @@ export async function getShareableLists(
  * @param db
  * @param externalId
  */
-export async function searchShareableList(
+export function searchShareableList(
   db: PrismaClient,
   externalId: string
 ): Promise<ShareableListComplete> {

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -1,6 +1,7 @@
 import { PocketDefaultScalars } from '@pocket-tools/apollo-utils';
 import { PrismaBigIntResolver } from '../../shared/resolvers/fields/PrismaBigInt';
 import { getShareableList, getShareableLists } from './queries/ShareableList';
+import { isPilotUser } from './queries/PilotUser';
 import {
   createShareableList,
   deleteShareableList,
@@ -26,5 +27,6 @@ export const resolvers = {
   Query: {
     shareableList: getShareableList,
     shareableLists: getShareableLists,
+    isPilotUser,
   },
 };

--- a/src/public/resolvers/queries/PilotUser.integration.ts
+++ b/src/public/resolvers/queries/PilotUser.integration.ts
@@ -1,0 +1,71 @@
+import { ApolloServer } from '@apollo/server';
+import { PilotUser, PrismaClient } from '@prisma/client';
+import { print } from 'graphql';
+import request from 'supertest';
+import { IPublicContext } from '../../context';
+import { startServer } from '../../../express';
+import { client } from '../../../database/client';
+import { clearDb, createPilotUserHelper } from '../../../test/helpers';
+import { IS_PILOT_USER } from './sample-queries.gql';
+import { expect } from 'chai';
+
+describe('public queries: PilotUser', () => {
+  let app: Express.Application;
+  let server: ApolloServer<IPublicContext>;
+  let graphQLUrl: string;
+  let db: PrismaClient;
+
+  let pilotUser: PilotUser;
+
+  beforeAll(async () => {
+    // port 0 tells express to dynamically assign an available port
+    ({
+      app,
+      publicServer: server,
+      publicUrl: graphQLUrl,
+    } = await startServer(0));
+
+    db = client();
+
+    // create a pilot user
+    pilotUser = await createPilotUserHelper(db, {
+      userId: 8009882300,
+    });
+  });
+
+  afterAll(async () => {
+    await clearDb(db);
+    await db.$disconnect();
+    await server.stop();
+  });
+
+  describe('isPilotUser query', () => {
+    it('should return true if user is in the pilot', async () => {
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set({
+          // the id of the pilot user we created above
+          userId: pilotUser.userId.toString(),
+        })
+        .send({
+          query: print(IS_PILOT_USER),
+        });
+
+      expect(result.body.data.isPilotUser).to.be.true;
+    });
+
+    it('should return false if user is not in the pilot', async () => {
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set({
+          // *not* the id of the pilot user we created above
+          userId: '7732025862',
+        })
+        .send({
+          query: print(IS_PILOT_USER),
+        });
+
+      expect(result.body.data.isPilotUser).to.be.false;
+    });
+  });
+});

--- a/src/public/resolvers/queries/PilotUser.ts
+++ b/src/public/resolvers/queries/PilotUser.ts
@@ -1,0 +1,13 @@
+import { isPilotUser as dbIsPilotUser } from '../../../database/queries';
+
+/**
+ * Resolver for the public 'isPilotUser` query.
+ *
+ * @param parent
+ * @param _ // no input on this query
+ * @param userId // in context
+ * @param db // in context
+ */
+export async function isPilotUser(parent, _, { userId, db }): Promise<boolean> {
+  return (await dbIsPilotUser(db, userId)) > 0 ? true : false;
+}

--- a/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/src/public/resolvers/queries/sample-queries.gql.ts
@@ -18,3 +18,9 @@ export const GET_SHAREABLE_LISTS = gql`
   }
   ${ShareableListPublicProps}
 `;
+
+export const IS_PILOT_USER = gql`
+  query isPilotUser {
+    isPilotUser
+  }
+`;

--- a/src/test/helpers/cleardb.ts
+++ b/src/test/helpers/cleardb.ts
@@ -10,4 +10,5 @@ export async function clearDb(prisma: PrismaClient): Promise<void> {
   // Delete data from each table, starting with tables that contain foreign keys
   await prisma.listItem.deleteMany({});
   await prisma.list.deleteMany({});
+  await prisma.pilotUser.deleteMany({});
 }

--- a/src/test/helpers/createPilotUserHelper.ts
+++ b/src/test/helpers/createPilotUserHelper.ts
@@ -1,0 +1,23 @@
+import { PilotUser, PrismaClient } from '@prisma/client';
+
+interface PilotUserInput {
+  userId: number | bigint;
+  // fields below are for potential future use
+  mozillaEmployee?: boolean;
+  createdBy?: string;
+}
+
+/**
+ * Generates a Pilot User
+ *
+ * @param prisma
+ * @param data
+ */
+export async function createPilotUserHelper(
+  prisma: PrismaClient,
+  data: PilotUserInput
+): Promise<PilotUser> {
+  return await prisma.pilotUser.create({
+    data,
+  });
+}

--- a/src/test/helpers/index.ts
+++ b/src/test/helpers/index.ts
@@ -2,3 +2,4 @@ export { clearDb } from './cleardb';
 export { createShareableListHelper } from './createShareableListHelper';
 export { createShareableListItemHelper } from './createShareableListItemHelper';
 export { updateShareableListHelper } from './updateShareableListHelper';
+export { createPilotUserHelper } from './createPilotUserHelper';


### PR DESCRIPTION
## Goal

add a basic query to know if the `userId` passed in the header is a part of the pilot program.

- removed unnecessary async declarations

## Tickets

- https://getpocket.atlassian.net/browse/OSL-248

## Implementation Decisions

removed `async` declarations on functions that have no `await` calls. (i don't think this has any performance impact either way, but it's not needed.)
