### PR TITLE
fix(list title update): sending existing title should not fail

### DIFF
--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -75,9 +75,13 @@ export async function updateShareableList(
 
   // If the title is getting updated, check if the user already has a list
   // with the same title.
-  if (data.title) {
+  if (data.title && data.title !== list.title) {
     const titleExists = await db.list.count({
-      where: { title: data.title, userId: userId },
+      where: {
+        title: data.title,
+        userId: userId,
+        externalId: { not: data.externalId },
+      },
     });
 
     if (titleExists) {

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -331,7 +331,7 @@ describe('public mutations: ShareableList', () => {
       // Create a List
       listToUpdate = await createShareableListHelper(db, {
         userId: parseInt(headers.userId),
-        title: '<marquee>The Most Shareable List</marquee>',
+        title: 'The Most Shareable List',
       });
     });
 
@@ -431,6 +431,31 @@ describe('public mutations: ShareableList', () => {
         'errors[0].extensions.code',
         'BAD_USER_INPUT'
       );
+    });
+
+    it('should allow the update if the existing title is passed', async () => {
+      const data: UpdateShareableListInput = {
+        externalId: listToUpdate.externalId,
+        title: listToUpdate.title, // send the existing title
+        description: 'my b i forgot the description last time',
+      };
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_SHAREABLE_LIST),
+          variables: { data },
+        });
+
+      // There should be no errors
+      expect(result.body.errors).to.be.undefined;
+
+      // A result should be returned
+      expect(result.body.data.updateShareableList).not.to.be.null;
+
+      // the title should remain unchanged
+      expect(result.body.data.updateShareableList.title).to.equal(data.title);
     });
 
     it('should generate a slug if a list is being made public for the first time', async () => {


### PR DESCRIPTION
## Goal

fix a bug where sending the list's current title value to `updateShareableList` would cause a "duplicate title" error.

## Reference

- [Slack thread](https://pocket.slack.com/archives/C04HWMUKLN5/p1677865852780239)

## Tickets

- https://getpocket.atlassian.net/browse/OSL-251