### PR TITLE
OSL-243: add listItemData param to createShareableList mutation

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -135,7 +135,11 @@ input UpdateShareableListInput {
 Input data for creating a Shareable List Item.
 """
 input CreateShareableListItemInput {
-  listExternalId: ID!
+  """
+  listExternalId parameter is optional as it is not
+  required when creating a ShareableList with a ShareableListItem
+  """
+  listExternalId: ID
   itemId: Float
   url: Url!
   title: String
@@ -167,9 +171,13 @@ type Query {
 
 type Mutation {
   """
-  Creates a Shareable List.
+  Creates a Shareable List. Takes in an optional listItemData parameter to create a ShareableListItem
+  along with a ShareableList.
   """
-  createShareableList(data: CreateShareableListInput!): ShareableList
+  createShareableList(
+    listData: CreateShareableListInput!
+    listItemData: CreateShareableListItemInput
+  ): ShareableList
   """
   Deletes a Shareable List.
   """

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -135,6 +135,21 @@ input UpdateShareableListInput {
 Input data for creating a Shareable List Item.
 """
 input CreateShareableListItemInput {
+  listExternalId: ID!
+  itemId: Float
+  url: Url!
+  title: String
+  excerpt: String
+  imageUrl: Url
+  publisher: String
+  authors: String
+  sortOrder: Int!
+}
+
+"""
+Input data for creating a Shareable List Item during Shareable List creation.
+"""
+input CreateShareableListItemWithShareableListInput {
   """
   listExternalId parameter is optional as it is not
   required when creating a ShareableList with a ShareableListItem
@@ -176,7 +191,7 @@ type Mutation {
   """
   createShareableList(
     listData: CreateShareableListInput!
-    listItemData: CreateShareableListItemInput
+    listItemData: CreateShareableListItemWithShareableListInput
   ): ShareableList
   """
   Deletes a Shareable List.

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -149,12 +149,7 @@ input CreateShareableListItemInput {
 """
 Input data for creating a Shareable List Item during Shareable List creation.
 """
-input CreateShareableListItemWithShareableListInput {
-  """
-  listExternalId parameter is optional as it is not
-  required when creating a ShareableList with a ShareableListItem
-  """
-  listExternalId: ID
+input CreateShareableListItemWithList {
   itemId: Float
   url: Url!
   title: String
@@ -191,7 +186,7 @@ type Mutation {
   """
   createShareableList(
     listData: CreateShareableListInput!
-    listItemData: CreateShareableListItemWithShareableListInput
+    listItemData: CreateShareableListItemWithList
   ): ShareableList
   """
   Deletes a Shareable List.

--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -8,7 +8,10 @@ import {
   ShareableListComplete,
   UpdateShareableListInput,
 } from '../types';
-import { deleteAllListItemsForList } from './ShareableListItem';
+import {
+  createShareableListItem,
+  deleteAllListItemsForList,
+} from './ShareableListItem';
 import {
   LIST_TITLE_MAX_CHARS,
   LIST_DESCRIPTION_MAX_CHARS,
@@ -26,32 +29,53 @@ import config from '../../config';
  */
 export async function createShareableList(
   db: PrismaClient,
-  data: CreateShareableListInput,
+  listData: CreateShareableListInput,
   userId: number | bigint
 ): Promise<ShareableList> {
+  let listItemData;
+  let list;
+
   // check if the title already exists for this user
   const titleExists = await db.list.count({
-    where: { title: data.title, userId: userId },
+    where: { title: listData.title, userId: userId },
   });
 
   if (titleExists) {
     throw new UserInputError(
-      `A list with the title "${data.title}" already exists`
+      `A list with the title "${listData.title}" already exists`
     );
   }
 
   // check list title and descipriotn length
   shareableListTitleDescriptionValidation(
-    data.title,
-    data.description ? data.description : null
+    listData.title,
+    listData.description ? listData.description : null
   );
 
-  return db.list.create({
-    data: { ...data, userId },
+  // check if listItem data is passed
+  if (listData.listItem) {
+    listItemData = listData.listItem;
+    //remove it from listData so that we can create the ShareableList first
+    delete listData.listItem;
+  }
+
+  // create ShareableList in db
+  list = await db.list.create({
+    data: { ...listData, userId },
     include: {
       listItems: true,
     },
   });
+  // if ShareableListItem was passed in the request, create it in the db
+  if (listItemData) {
+    // first set the list external id
+    listItemData['listExternalId'] = list.externalId;
+    // create the ShareableListItem
+    await createShareableListItem(db, listItemData, userId);
+    // look up the ShareableList with the created ShareableListItem included in the result
+    list = getShareableList(db, userId, list.externalId);
+  }
+  return list;
 }
 
 /**

--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -33,7 +33,7 @@ export async function createShareableList(
   userId: number | bigint
 ): Promise<ShareableList> {
   let listItemData;
-  let list;
+  // let list;
 
   // check if the title already exists for this user
   const titleExists = await db.list.count({
@@ -60,7 +60,7 @@ export async function createShareableList(
   }
 
   // create ShareableList in db
-  list = await db.list.create({
+  const list: ShareableList = await db.list.create({
     data: { ...listData, userId },
     include: {
       listItems: true,
@@ -77,7 +77,7 @@ export async function createShareableList(
       userId
     );
     // add the created ShareableListItem to the created ShareableList
-    list['listItems'] = [createdListItem];
+    list.listItems = [createdListItem];
   }
   return list;
 }

--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -71,9 +71,13 @@ export async function createShareableList(
     // first set the list external id
     listItemData['listExternalId'] = list.externalId;
     // create the ShareableListItem
-    await createShareableListItem(db, listItemData, userId);
-    // look up the ShareableList with the created ShareableListItem included in the result
-    list = getShareableList(db, userId, list.externalId);
+    const createdListItem = await createShareableListItem(
+      db,
+      listItemData,
+      userId
+    );
+    // add the created ShareableListItem to the created ShareableList
+    list['listItems'] = [createdListItem];
   }
   return list;
 }

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -47,7 +47,7 @@ export type ModerateShareableListInput = {
 };
 
 export type CreateShareableListItemInput = {
-  listExternalId?: string;
+  listExternalId: string;
   itemId?: number;
   url: string;
   title?: string;

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -25,6 +25,7 @@ export type ShareableListComplete = Omit<List, 'id'>;
 export type CreateShareableListInput = {
   title: string;
   description?: string;
+  listItem?: CreateShareableListItemInput;
 };
 
 export type UpdateShareableListInput = {
@@ -46,7 +47,7 @@ export type ModerateShareableListInput = {
 };
 
 export type CreateShareableListItemInput = {
-  listExternalId: string;
+  listExternalId?: string;
   itemId?: number;
   url: string;
   title?: string;

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -15,7 +15,6 @@ import { IPublicContext } from '../../context';
 import { client } from '../../../database/client';
 import {
   CreateShareableListInput,
-  CreateShareableListItemInput,
   UpdateShareableListInput,
 } from '../../../database/types';
 import {

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -125,7 +125,7 @@ describe('public mutations: ShareableList', () => {
         description: faker.lorem.sentences(2),
       };
 
-      const listItemData: CreateShareableListItemInput = {
+      const listItemData = {
         itemId: 3789538749,
         url: 'https://www.test.com/this-is-a-story',
         title: 'A story is a story',

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -15,6 +15,7 @@ import { IPublicContext } from '../../context';
 import { client } from '../../../database/client';
 import {
   CreateShareableListInput,
+  CreateShareableListItemInput,
   UpdateShareableListInput,
 } from '../../../database/types';
 import {
@@ -82,7 +83,7 @@ describe('public mutations: ShareableList', () => {
         .post(graphQLUrl)
         .send({
           query: print(CREATE_SHAREABLE_LIST),
-          variables: { data },
+          variables: { listData: data },
         });
       expect(result.body.data.createShareableList).not.to.exist;
       expect(result.body.errors.length).to.equal(1);
@@ -90,7 +91,7 @@ describe('public mutations: ShareableList', () => {
       expect(result.body.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
     });
 
-    it('should create a new List', async () => {
+    it('should create a new List without ListItem', async () => {
       const title = 'My list to share<script>alert("Hello World!")</script>';
       const data: CreateShareableListInput = {
         title: title,
@@ -101,7 +102,7 @@ describe('public mutations: ShareableList', () => {
         .set(headers)
         .send({
           query: print(CREATE_SHAREABLE_LIST),
-          variables: { data },
+          variables: { listData: data },
         });
       expect(result.body.data).to.exist;
       expect(result.body.data.createShareableList.title).to.equal(
@@ -112,6 +113,49 @@ describe('public mutations: ShareableList', () => {
       );
       expect(result.body.data.createShareableList.moderationStatus).to.equal(
         ModerationStatus.VISIBLE
+      );
+      // expect no listItems in result
+      expect(result.body.data.createShareableList.listItems.length).to.equal(0);
+    });
+
+    it('should create a new List with a ListItem', async () => {
+      const title = 'My list to share<script>alert("Hello World!")</script>';
+      const listData: CreateShareableListInput = {
+        title: title,
+        description: faker.lorem.sentences(2),
+      };
+
+      const listItemData: CreateShareableListItemInput = {
+        itemId: 3789538749,
+        url: 'https://www.test.com/this-is-a-story',
+        title: 'A story is a story',
+        excerpt: '<blink>The best story ever told</blink>',
+        imageUrl: 'https://www.test.com/thumbnail.jpg',
+        publisher: 'The London Times',
+        authors: 'Charles Dickens, Mark Twain',
+        sortOrder: 10,
+      };
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(CREATE_SHAREABLE_LIST),
+          variables: { listData, listItemData },
+        });
+      expect(result.body.data).to.exist;
+      expect(result.body.data.createShareableList.title).to.equal(
+        'My list to share&lt;script&gt;alert("Hello World!")&lt;/script&gt;'
+      );
+      expect(result.body.data.createShareableList.status).to.equal(
+        ListStatus.PRIVATE
+      );
+      expect(result.body.data.createShareableList.moderationStatus).to.equal(
+        ModerationStatus.VISIBLE
+      );
+      // expect 1 listItem in result
+      expect(result.body.data.createShareableList.listItems.length).to.equal(1);
+      expect(result.body.data.createShareableList.listItems[0].title).to.equal(
+        listItemData.title
       );
     });
 
@@ -131,7 +175,7 @@ describe('public mutations: ShareableList', () => {
         .set(headers)
         .send({
           query: print(CREATE_SHAREABLE_LIST),
-          variables: { data },
+          variables: { listData: data },
         });
       expect(result.body.data.createShareableList).not.to.exist;
       expect(result.body.errors.length).to.equal(1);
@@ -151,7 +195,7 @@ describe('public mutations: ShareableList', () => {
         .set(headers)
         .send({
           query: print(CREATE_SHAREABLE_LIST),
-          variables: { data },
+          variables: { listData: data },
         });
       expect(result.body.data.createShareableList).not.to.exist;
       expect(result.body.errors.length).to.equal(1);
@@ -171,7 +215,7 @@ describe('public mutations: ShareableList', () => {
         .set(headers)
         .send({
           query: print(CREATE_SHAREABLE_LIST),
-          variables: { data },
+          variables: { listData: data },
         });
       expect(result.body.data.createShareableList).not.to.exist;
       expect(result.body.errors.length).to.equal(1);
@@ -197,7 +241,7 @@ describe('public mutations: ShareableList', () => {
         .set(headers)
         .send({
           query: print(CREATE_SHAREABLE_LIST),
-          variables: { data },
+          variables: { listData: data },
         });
       expect(result.body.data.createShareableList).to.exist;
       expect(result.body.data.createShareableList.title).to.equal(title1);
@@ -219,7 +263,7 @@ describe('public mutations: ShareableList', () => {
         .set(headers)
         .send({
           query: print(CREATE_SHAREABLE_LIST),
-          variables: { data },
+          variables: { listData: data },
         });
       expect(result.body.data.createShareableList).to.exist;
       expect(result.body.data.createShareableList.title).to.equal(

--- a/src/public/resolvers/mutations/ShareableList.ts
+++ b/src/public/resolvers/mutations/ShareableList.ts
@@ -18,12 +18,15 @@ import { executeMutation } from './utils';
  */
 export async function createShareableList(
   parent,
-  { data },
+  { listData, listItemData },
   context: IPublicContext
 ): Promise<ShareableList> {
+  if (listItemData) {
+    listData['listItem'] = listItemData;
+  }
   return await executeMutation<CreateShareableListInput, ShareableList>(
     context,
-    data,
+    listData,
     dbCreateShareableList
   );
 }

--- a/src/public/resolvers/mutations/sample-mutations.gql.ts
+++ b/src/public/resolvers/mutations/sample-mutations.gql.ts
@@ -7,7 +7,7 @@ import {
 export const CREATE_SHAREABLE_LIST = gql`
   mutation createShareableList(
     $listData: CreateShareableListInput!
-    $listItemData: CreateShareableListItemWithShareableListInput
+    $listItemData: CreateShareableListItemWithList
   ) {
     createShareableList(listData: $listData, listItemData: $listItemData) {
       ...ShareableListPublicProps

--- a/src/public/resolvers/mutations/sample-mutations.gql.ts
+++ b/src/public/resolvers/mutations/sample-mutations.gql.ts
@@ -7,7 +7,7 @@ import {
 export const CREATE_SHAREABLE_LIST = gql`
   mutation createShareableList(
     $listData: CreateShareableListInput!
-    $listItemData: CreateShareableListItemInput
+    $listItemData: CreateShareableListItemWithShareableListInput
   ) {
     createShareableList(listData: $listData, listItemData: $listItemData) {
       ...ShareableListPublicProps

--- a/src/public/resolvers/mutations/sample-mutations.gql.ts
+++ b/src/public/resolvers/mutations/sample-mutations.gql.ts
@@ -5,8 +5,11 @@ import {
 } from '../fragments.gql';
 
 export const CREATE_SHAREABLE_LIST = gql`
-  mutation createShareableList($data: CreateShareableListInput!) {
-    createShareableList(data: $data) {
+  mutation createShareableList(
+    $listData: CreateShareableListInput!
+    $listItemData: CreateShareableListItemInput
+  ) {
+    createShareableList(listData: $listData, listItemData: $listItemData) {
       ...ShareableListPublicProps
     }
   }


### PR DESCRIPTION
## Goal

According to t[his slack thread](https://pocket.slack.com/archives/C04HWMUKLN5/p1677691820523829), we want to have the option to create a `ShareableListItem` when creating a `ShareableList`. Updating the `createShareableList` mutation to take in an optional `listItemData` param.

## Todos

- [ ] deploy to dev

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-243](https://getpocket.atlassian.net/browse/OSL-243)
