### PR TITLE
feat(API authorization): validate pilot user on necessary API calls

### DIFF
--- a/src/database/queries/PilotUser.ts
+++ b/src/database/queries/PilotUser.ts
@@ -10,6 +10,7 @@ export function isPilotUser(
   db: PrismaClient,
   userId: number | bigint
 ): Promise<number> {
+  // we could probably use redis here as an extra cache layer
   return db.pilotUser.count({
     where: {
       userId,

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -44,7 +44,6 @@ describe('public mutations: ShareableList', () => {
   let graphQLUrl: string;
   let db: PrismaClient;
   let eventBridgeClientStub: sinon.SinonStub;
-  let pilotUser1: PilotUser;
   let pilotUser2: PilotUser;
 
   const headers = {
@@ -75,7 +74,7 @@ describe('public mutations: ShareableList', () => {
     await clearDb(db);
 
     // create pilot users
-    pilotUser1 = await createPilotUserHelper(db, {
+    await createPilotUserHelper(db, {
       userId: parseInt(headers.userId),
     });
 

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -7,6 +7,7 @@ import {
   List,
   ListStatus,
   ModerationStatus,
+  PilotUser,
   PrismaClient,
 } from '@prisma/client';
 import { EventBridgeClient } from '@aws-sdk/client-eventbridge';
@@ -26,6 +27,7 @@ import {
 } from './sample-mutations.gql';
 import {
   clearDb,
+  createPilotUserHelper,
   createShareableListHelper,
   createShareableListItemHelper,
 } from '../../../test/helpers';
@@ -42,9 +44,11 @@ describe('public mutations: ShareableList', () => {
   let graphQLUrl: string;
   let db: PrismaClient;
   let eventBridgeClientStub: sinon.SinonStub;
+  let pilotUser1: PilotUser;
+  let pilotUser2: PilotUser;
 
   const headers = {
-    userId: '12345',
+    userId: '8009882300',
   };
 
   beforeAll(async () => {
@@ -69,6 +73,15 @@ describe('public mutations: ShareableList', () => {
 
   beforeEach(async () => {
     await clearDb(db);
+
+    // create pilot users
+    pilotUser1 = await createPilotUserHelper(db, {
+      userId: parseInt(headers.userId),
+    });
+
+    pilotUser2 = await createPilotUserHelper(db, {
+      userId: 7732025862,
+    });
   });
 
   describe('createShareableList', () => {
@@ -88,6 +101,27 @@ describe('public mutations: ShareableList', () => {
       };
       const result = await request(app)
         .post(graphQLUrl)
+        .send({
+          query: print(CREATE_SHAREABLE_LIST),
+          variables: { listData: data },
+        });
+      expect(result.body.data.createShareableList).not.to.exist;
+      expect(result.body.errors.length).to.equal(1);
+      expect(result.body.errors[0].extensions.code).to.equal('FORBIDDEN');
+      expect(result.body.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+    });
+
+    it('should not create a new List for a non-pilot user', async () => {
+      const title = faker.random.words(2);
+      const data: CreateShareableListInput = {
+        title: title,
+        description: faker.lorem.sentences(2),
+      };
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set({
+          userId: '848135',
+        })
         .send({
           query: print(CREATE_SHAREABLE_LIST),
           variables: { listData: data },
@@ -449,10 +483,7 @@ describe('public mutations: ShareableList', () => {
       expect(result.body.data).to.be.null;
 
       // And a "Not found" error
-      expect(result.body).to.have.nested.property(
-        'errors[0].extensions.code',
-        'NOT_FOUND'
-      );
+      expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
     });
 
     it('should reject the update if user already has a list with the same title', async () => {
@@ -479,10 +510,7 @@ describe('public mutations: ShareableList', () => {
       expect(result.body.data).to.be.null;
 
       // And a "Bad user input" error
-      expect(result.body).to.have.nested.property(
-        'errors[0].extensions.code',
-        'BAD_USER_INPUT'
-      );
+      expect(result.body.errors[0].extensions.code).to.equal('BAD_USER_INPUT');
     });
 
     it('should allow the update if the existing title is passed', async () => {
@@ -705,7 +733,7 @@ describe('public mutations: ShareableList', () => {
       );
 
       const headersUser2 = {
-        userId: '98765',
+        userId: pilotUser2.userId,
       };
       const secondList = await createShareableListHelper(db, {
         title: `Hangover Hotel`,
@@ -817,10 +845,7 @@ describe('public mutations: ShareableList', () => {
       expect(result.body.data).to.be.null;
 
       // And a "Bad user input" error
-      expect(result.body).to.have.nested.property(
-        'errors[0].extensions.code',
-        'BAD_USER_INPUT'
-      );
+      expect(result.body.errors[0].extensions.code).to.equal('BAD_USER_INPUT');
       expect(result.body.errors[0].message).to.equal(
         `List title must not be longer than 100 characters`
       );
@@ -844,10 +869,7 @@ describe('public mutations: ShareableList', () => {
       expect(result.body.data).to.be.null;
 
       // And a "Bad user input" error
-      expect(result.body).to.have.nested.property(
-        'errors[0].extensions.code',
-        'BAD_USER_INPUT'
-      );
+      expect(result.body.errors[0].extensions.code).to.equal('BAD_USER_INPUT');
       expect(result.body.errors[0].message).to.equal(
         `List description must not be longer than 200 characters`
       );

--- a/src/public/resolvers/queries/PilotUser.integration.ts
+++ b/src/public/resolvers/queries/PilotUser.integration.ts
@@ -26,6 +26,10 @@ describe('public queries: PilotUser', () => {
     } = await startServer(0));
 
     db = client();
+  });
+
+  beforeEach(async () => {
+    await clearDb(db);
 
     // create a pilot user
     pilotUser = await createPilotUserHelper(db, {
@@ -34,7 +38,6 @@ describe('public queries: PilotUser', () => {
   });
 
   afterAll(async () => {
-    await clearDb(db);
     await db.$disconnect();
     await server.stop();
   });
@@ -60,6 +63,20 @@ describe('public queries: PilotUser', () => {
         .set({
           // *not* the id of the pilot user we created above
           userId: '7732025862',
+        })
+        .send({
+          query: print(SHAREABLE_LISTS_PILOT_USER),
+        });
+
+      expect(result.body.data.shareableListsPilotUser).to.be.false;
+    });
+
+    it('should return false if userId is empty', async () => {
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set({
+          // userId is not set
+          userId: '',
         })
         .send({
           query: print(SHAREABLE_LISTS_PILOT_USER),

--- a/src/public/resolvers/queries/PilotUser.ts
+++ b/src/public/resolvers/queries/PilotUser.ts
@@ -10,5 +10,9 @@ import { validateUserId } from '../utils';
  * @param db // in context
  */
 export async function isPilotUser(parent, _, { userId, db }): Promise<boolean> {
-  return (await dbIsPilotUser(db, validateUserId(userId))) > 0 ? true : false;
+  if (isNaN(userId)) {
+    return false;
+  }
+
+  return (await dbIsPilotUser(db, userId)) > 0 ? true : false;
 }

--- a/src/public/resolvers/queries/PilotUser.ts
+++ b/src/public/resolvers/queries/PilotUser.ts
@@ -1,5 +1,4 @@
 import { isPilotUser as dbIsPilotUser } from '../../../database/queries';
-import { validateUserId } from '../utils';
 
 /**
  * Resolver for the public 'isPilotUser` query.

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -34,7 +34,6 @@ describe('public queries: ShareableList', () => {
   let db: PrismaClient;
   let shareableList: List;
   let shareableList2: List;
-  let pilotUser1: PilotUser;
   let pilotUser2: PilotUser;
 
   const headers = {
@@ -59,7 +58,7 @@ describe('public queries: ShareableList', () => {
   beforeEach(async () => {
     await clearDb(db);
 
-    pilotUser1 = await createPilotUserHelper(db, {
+    await createPilotUserHelper(db, {
       userId: parseInt(headers.userId),
     });
 

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -1,17 +1,22 @@
+import { expect } from 'chai';
+import { print } from 'graphql';
+import request from 'supertest';
+
 import { ApolloServer } from '@apollo/server';
 import {
   List,
   ListStatus,
   ModerationStatus,
+  PilotUser,
   PrismaClient,
 } from '@prisma/client';
-import { print } from 'graphql';
-import request from 'supertest';
+
 import { IPublicContext } from '../../context';
 import { startServer } from '../../../express';
 import { client } from '../../../database/client';
 import {
   clearDb,
+  createPilotUserHelper,
   createShareableListHelper,
   createShareableListItemHelper,
 } from '../../../test/helpers';
@@ -20,7 +25,7 @@ import {
   GET_SHAREABLE_LIST_PUBLIC,
   GET_SHAREABLE_LISTS,
 } from './sample-queries.gql';
-import { expect } from 'chai';
+import { ACCESS_DENIED_ERROR } from '../../../shared/constants';
 
 describe('public queries: ShareableList', () => {
   let app: Express.Application;
@@ -29,6 +34,8 @@ describe('public queries: ShareableList', () => {
   let db: PrismaClient;
   let shareableList: List;
   let shareableList2: List;
+  let pilotUser1: PilotUser;
+  let pilotUser2: PilotUser;
 
   const headers = {
     userId: '123456789',
@@ -52,6 +59,14 @@ describe('public queries: ShareableList', () => {
   beforeEach(async () => {
     await clearDb(db);
 
+    pilotUser1 = await createPilotUserHelper(db, {
+      userId: parseInt(headers.userId),
+    });
+
+    pilotUser2 = await createPilotUserHelper(db, {
+      userId: 8009882300,
+    });
+
     // create a list to be used in tests (no list items)
     shareableList = await createShareableListHelper(db, {
       userId: parseInt(headers.userId),
@@ -66,6 +81,26 @@ describe('public queries: ShareableList', () => {
   });
 
   describe('shareableList query', () => {
+    it('should not return a list for a user not in the pilot', async () => {
+      // Run the query we're testing
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set({
+          userId: '848135',
+        })
+        .send({
+          query: print(GET_SHAREABLE_LIST),
+          variables: {
+            externalId: shareableList.externalId,
+          },
+        });
+
+      // There should be nothing in results
+      expect(result.body.data.shareableList).to.be.null;
+
+      expect(result.body.errors[0].extensions.code).to.equal('FORBIDDEN');
+      expect(result.body.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+    });
     it('should return a "Not Found" error if no list exists', async () => {
       // Run the query we're testing
       const result = await request(app)
@@ -82,10 +117,7 @@ describe('public queries: ShareableList', () => {
       expect(result.body.data.shareableList).to.be.null;
 
       // And a "Not found" error
-      expect(result.body).to.have.nested.property(
-        'errors[0].extensions.code',
-        'NOT_FOUND'
-      );
+      expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
     });
 
     it('should return a list with all props if it exists', async () => {
@@ -187,10 +219,7 @@ describe('public queries: ShareableList', () => {
       expect(result.body.data.shareableListPublic).to.be.null;
 
       // And a "Not found" error
-      expect(result.body).to.have.nested.property(
-        'errors[0].extensions.code',
-        'NOT_FOUND'
-      );
+      expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
     });
 
     it('should return a 403 error if list has been taken down', async () => {
@@ -218,10 +247,8 @@ describe('public queries: ShareableList', () => {
       expect(result.body.data.shareableListPublic).to.be.null;
 
       // And a "Forbidden" error
-      expect(result.body).to.have.nested.property(
-        'errors[0].extensions.code',
-        'FORBIDDEN'
-      );
+      expect(result.body.errors[0].extensions.code).to.equal('FORBIDDEN');
+      expect(result.body.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
     });
 
     it('should return a list with all props if it is accessible', async () => {
@@ -323,9 +350,26 @@ describe('public queries: ShareableList', () => {
   });
 
   describe('shareableLists query', () => {
+    it('should not return results for a user not in the pilot', async () => {
+      // Run the query we're testing
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set({
+          userId: '848135',
+        })
+        .send({
+          query: print(GET_SHAREABLE_LISTS),
+        });
+
+      // The returned shareableLists array should be empty
+      expect(result.body.data).to.be.null;
+
+      expect(result.body.errors[0].extensions.code).to.equal('FORBIDDEN');
+      expect(result.body.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+    });
     it('should return an empty shareableLists array if no lists exist for a given userId', async () => {
       // set headers for userId which has no lists
-      const testHeaders = { userId: '9876' };
+      const testHeaders = { userId: pilotUser2.userId };
       // Run the query we're testing
       const result = await request(app)
         .post(graphQLUrl)

--- a/src/public/resolvers/queries/ShareableList.ts
+++ b/src/public/resolvers/queries/ShareableList.ts
@@ -20,7 +20,11 @@ export async function getShareableList(
   { externalId },
   { userId, db }
 ): Promise<ShareableList> {
-  const list = await dbGetShareableList(db, validateUserId(userId), externalId);
+  const list = await dbGetShareableList(
+    db,
+    await validateUserId(db, userId),
+    externalId
+  );
 
   if (!list) {
     throw new NotFoundError(externalId);
@@ -62,5 +66,5 @@ export async function getShareableLists(
   _,
   { userId, db }
 ): Promise<ShareableList[]> {
-  return await dbGetShareableLists(db, validateUserId(userId));
+  return await dbGetShareableLists(db, await validateUserId(db, userId));
 }


### PR DESCRIPTION
## Goal

validate the `userId` in headers is in the pilot user group. applies to all public API endpoints _except_ `shareableListPublic`.

- standardize integration test error checking

## Tickets

- https://getpocket.atlassian.net/browse/OSL-196