### PR TITLE
OSL-263: shareableListPublic query should not return PRIVATE list

### DIFF
--- a/src/database/queries/ShareableList.ts
+++ b/src/database/queries/ShareableList.ts
@@ -42,6 +42,8 @@ export async function getShareableListPublic(
   db: PrismaClient,
   externalId: string
 ): Promise<ShareableList> {
+  // externalId is unique, but the generated type for `findUnique` here doesn't
+  // include `status`, so using `findFirst` instead
   const list = await db.list.findFirst({
     where: {
       externalId,

--- a/src/database/queries/ShareableList.ts
+++ b/src/database/queries/ShareableList.ts
@@ -1,4 +1,4 @@
-import { ModerationStatus, PrismaClient } from '@prisma/client';
+import { ListStatus, ModerationStatus, PrismaClient } from '@prisma/client';
 import { ShareableList, ShareableListComplete } from '../types';
 import { ForbiddenError, NotFoundError } from '@pocket-tools/apollo-utils';
 import { ACCESS_DENIED_ERROR } from '../../shared/constants';
@@ -42,9 +42,10 @@ export async function getShareableListPublic(
   db: PrismaClient,
   externalId: string
 ): Promise<ShareableList> {
-  const list = await db.list.findUnique({
+  const list = await db.list.findFirst({
     where: {
       externalId,
+      status: ListStatus.PUBLIC,
     },
     include: {
       listItems: true,

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -251,7 +251,7 @@ describe('public queries: ShareableList', () => {
     });
 
     it('should return a NotFound error if list is Private', async () => {
-      const newList = await createShareableListHelper(db, {
+      const privateList = await createShareableListHelper(db, {
         userId: parseInt(headers.userId),
         title: 'This is a list that is Private',
         status: ListStatus.PRIVATE,
@@ -264,7 +264,7 @@ describe('public queries: ShareableList', () => {
         .send({
           query: print(GET_SHAREABLE_LIST_PUBLIC),
           variables: {
-            externalId: newList.externalId,
+            externalId: privateList.externalId,
           },
         });
 

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -250,11 +250,39 @@ describe('public queries: ShareableList', () => {
       expect(result.body.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
     });
 
+    it('should return a NotFound error if list is Private', async () => {
+      const newList = await createShareableListHelper(db, {
+        userId: parseInt(headers.userId),
+        title: 'This is a list that is Private',
+        status: ListStatus.PRIVATE,
+        moderationStatus: ModerationStatus.VISIBLE,
+      });
+
+      // Run the query we're testing
+      const result = await request(app)
+        .post(graphQLUrl)
+        .send({
+          query: print(GET_SHAREABLE_LIST_PUBLIC),
+          variables: {
+            externalId: newList.externalId,
+          },
+        });
+
+      // There should be nothing in results
+      expect(result.body.data.shareableListPublic).to.be.null;
+
+      // And a "Forbidden" error
+      expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
+      expect(result.body.errors[0].message).to.equal(
+        'Error - Not Found: A list by that URL could not be found'
+      );
+    });
+
     it('should return a list with all props if it is accessible', async () => {
       const newList = await createShareableListHelper(db, {
         userId: parseInt(headers.userId),
-        title: 'This is a list that does not comply with our policies',
-        slug: 'this-is-a-list-that-does-not-comply',
+        title: 'This is a list that does comply with our policies',
+        slug: 'this-is-a-list-that-does-comply',
         status: ListStatus.PUBLIC,
         moderationStatus: ModerationStatus.VISIBLE,
       });


### PR DESCRIPTION
## Goal

This [slack thread](https://pocket.slack.com/archives/C04HWMUKLN5/p1678725002822039) informs that the `shareableListPublic` query returns both `PRIVATE` and `PUBLIC` list. This PR updates the query to return only a `PUBLIC` list.

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-263](https://getpocket.atlassian.net/browse/OSL-263)
