### PR TITLE
OSL-264: slug is required for shareableListPublic

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -161,15 +161,15 @@ input CreateShareableListItemWithList {
 }
 
 type Query {
-	"""
-	Looks up and returns a Shareable List with a given external ID for a given user.
-	(the user ID will be coming through with the headers)
-	"""
-	shareableList(externalId: ID!): ShareableList
+  """
+  Looks up and returns a Shareable List with a given external ID for a given user.
+  (the user ID will be coming through with the headers)
+  """
+  shareableList(externalId: ID!): ShareableList
   """
   Returns a publicly-shared Shareable List. Note: this query does not require user authentication.
   """
-  shareableListPublic(externalId: ID!): ShareableList
+  shareableListPublic(externalId: ID!, slug: String!): ShareableList
   """
   Looks up and returns an array of Shareable Lists for a given user ID for a given user.
   (the user ID will be coming through with the headers)

--- a/src/database/queries/ShareableList.ts
+++ b/src/database/queries/ShareableList.ts
@@ -40,13 +40,15 @@ export function getShareableList(
  */
 export async function getShareableListPublic(
   db: PrismaClient,
-  externalId: string
+  externalId: string,
+  slug: string
 ): Promise<ShareableList> {
   // externalId is unique, but the generated type for `findUnique` here doesn't
   // include `status`, so using `findFirst` instead
   const list = await db.list.findFirst({
     where: {
       externalId,
+      slug,
       status: ListStatus.PUBLIC,
     },
     include: {

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -211,9 +211,9 @@ describe('public queries: ShareableList', () => {
           query: print(GET_SHAREABLE_LIST_PUBLIC),
           variables: {
             externalId: '1234-abcd',
+            slug: 'bad-slug',
           },
         });
-
       // There should be nothing in results
       expect(result.body.data.shareableListPublic).to.be.null;
 
@@ -239,6 +239,7 @@ describe('public queries: ShareableList', () => {
           query: print(GET_SHAREABLE_LIST_PUBLIC),
           variables: {
             externalId: list.externalId,
+            slug: list.slug,
           },
         });
 
@@ -254,6 +255,7 @@ describe('public queries: ShareableList', () => {
       const privateList = await createShareableListHelper(db, {
         userId: parseInt(headers.userId),
         title: 'This is a list that is Private',
+        slug: 'this-is-a-list-that-is-private',
         status: ListStatus.PRIVATE,
         moderationStatus: ModerationStatus.VISIBLE,
       });
@@ -265,6 +267,37 @@ describe('public queries: ShareableList', () => {
           query: print(GET_SHAREABLE_LIST_PUBLIC),
           variables: {
             externalId: privateList.externalId,
+            slug: privateList.slug,
+          },
+        });
+
+      // There should be nothing in results
+      expect(result.body.data.shareableListPublic).to.be.null;
+
+      // And a "Forbidden" error
+      expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
+      expect(result.body.errors[0].message).to.equal(
+        'Error - Not Found: A list by that URL could not be found'
+      );
+    });
+
+    it('should return a NotFound error if externalId is valid but slug is invalid', async () => {
+      const newList = await createShareableListHelper(db, {
+        userId: parseInt(headers.userId),
+        title: 'This is a list',
+        slug: 'this-is-a-list',
+        status: ListStatus.PUBLIC,
+        moderationStatus: ModerationStatus.VISIBLE,
+      });
+
+      // Run the query we're testing
+      const result = await request(app)
+        .post(graphQLUrl)
+        .send({
+          query: print(GET_SHAREABLE_LIST_PUBLIC),
+          variables: {
+            externalId: newList.externalId,
+            slug: 'bad-slug',
           },
         });
 
@@ -294,6 +327,7 @@ describe('public queries: ShareableList', () => {
           query: print(GET_SHAREABLE_LIST_PUBLIC),
           variables: {
             externalId: newList.externalId,
+            slug: newList.slug,
           },
         });
 
@@ -346,6 +380,7 @@ describe('public queries: ShareableList', () => {
           query: print(GET_SHAREABLE_LIST_PUBLIC),
           variables: {
             externalId: newList.externalId,
+            slug: newList.slug,
           },
         });
 

--- a/src/public/resolvers/queries/ShareableList.ts
+++ b/src/public/resolvers/queries/ShareableList.ts
@@ -42,10 +42,10 @@ export async function getShareableList(
  */
 export async function getShareableListPublic(
   parent,
-  { externalId },
+  { externalId, slug },
   { db }
 ): Promise<ShareableList> {
-  const list = await dbGetShareableListPublic(db, externalId);
+  const list = await dbGetShareableListPublic(db, externalId, slug);
 
   if (!list) {
     throw new NotFoundError(externalId);

--- a/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/src/public/resolvers/queries/sample-queries.gql.ts
@@ -11,8 +11,8 @@ export const GET_SHAREABLE_LIST = gql`
 `;
 
 export const GET_SHAREABLE_LIST_PUBLIC = gql`
-  query shareableListPublic($externalId: ID!) {
-    shareableListPublic(externalId: $externalId) {
+  query shareableListPublic($externalId: ID!, $slug: String!) {
+    shareableListPublic(externalId: $externalId, slug: $slug) {
       ...ShareableListPublicProps
     }
   }


### PR DESCRIPTION
## Goal
Currently, the URL for a public shareable list ``{validExternalId}/{badSlug}` returns a valid article even if the `slug` is "bad".

Make `slug` required for `shareableListPublic` query to ensure that `{validExternalId}/{badSlug}` returns a `NotFound` error. 

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-264](https://getpocket.atlassian.net/browse/OSL-264)
