### PR TITLE
feat(User): resolve federated User entity

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -11,6 +11,13 @@ A URL to a web page or image.
 scalar Url
 
 """
+Resolve by reference the User entity in this graph to provide user data with public lists.
+"""
+type User @key(fields: "id", resolvable: false) {
+  id: ID!
+}
+
+"""
 A Pocket Save (story) that has been added to a Shareable List.
 """
 type ShareableListItem {
@@ -75,8 +82,13 @@ type ShareableList {
   UserId is of Float type as GraphQL does not support BigInt.
   This will ensure that all large integer values are handled
   and will be interpreted as Number type.
+  Will not federate userId, but available to be used locally.
   """
-  userId: Float!
+  userId: String! @inaccessible
+  """
+  The user who created this shareable list.
+  """
+  user: User!
   """
   A URL-ready identifier of the list. Generated from the title
   of the list when it's first made public. Unique per user.

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -1,3 +1,9 @@
+extend schema
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.0"
+    import: ["@key", "@shareable", "@requires", "@external", "@inaccessible"]
+  )
+
 """
 The status of a Shareable List. Defaults to PRIVATE - visible only to its owner.
 """

--- a/src/public/resolvers/fragments.gql.ts
+++ b/src/public/resolvers/fragments.gql.ts
@@ -27,7 +27,9 @@ export const ShareableListItemPublicProps = gql`
 export const ShareableListPublicProps = gql`
   fragment ShareableListPublicProps on ShareableList {
     externalId
-    userId
+    user {
+      id
+    }
     title
     description
     slug

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -1,5 +1,6 @@
 import { PocketDefaultScalars } from '@pocket-tools/apollo-utils';
 import { PrismaBigIntResolver } from '../../shared/resolvers/fields/PrismaBigInt';
+import { UserResolver } from '../../shared/resolvers/fields/User';
 import {
   getShareableList,
   getShareableListPublic,
@@ -20,6 +21,7 @@ export const resolvers = {
   ...PocketDefaultScalars,
   ShareableList: {
     userId: PrismaBigIntResolver,
+    user: UserResolver,
   },
   ShareableListItem: {
     itemId: PrismaBigIntResolver,

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -157,6 +157,9 @@ describe('public queries: ShareableList', () => {
       // Empty slug - it's not generated on creation
       expect(list.slug).to.be.null;
 
+      // the user entity should be present with the id of the creator
+      expect(list.user).to.deep.equal({ id: headers.userId });
+
       // Empty list items array
       expect(list.listItems).to.have.lengthOf(0);
     });
@@ -356,6 +359,9 @@ describe('public queries: ShareableList', () => {
       // Empty slug - it's not generated on creation
       expect(list.slug).to.not.be.empty;
 
+      // the user should match the id of the creator
+      expect(list.user).to.deep.equal({ id: newList.userId.toString() });
+
       // Empty list items array
       expect(list.listItems).to.have.lengthOf(0);
     });
@@ -524,6 +530,13 @@ describe('public queries: ShareableList', () => {
       expect(result.body.data.shareableLists[1].title).to.equal(
         shareableList.title
       );
+
+      expect(result.body.data.shareableLists[0].user).to.deep.equal({
+        id: headers.userId,
+      });
+      expect(result.body.data.shareableLists[1].user).to.deep.equal({
+        id: headers.userId,
+      });
 
       // Let's run through the visible props of each item
       // to make sure they're all there for the first List

--- a/src/shared/resolvers/fields/User.ts
+++ b/src/shared/resolvers/fields/User.ts
@@ -1,0 +1,14 @@
+/**
+ * Return an ojbect conforming to the User graphql definition.
+ *
+ * @param parent // a List
+ * @param args
+ * @param context
+ * @param info
+ */
+export const UserResolver = (parent, args, context, info) => {
+  // very basic data transformation!
+  return {
+    id: parent.userId.toString(),
+  };
+};


### PR DESCRIPTION
## Goal

resolve federated User entity.

- necessary to display user information on public lists
- remove userId from ShareableList in API (as user is now available)

[successfully pushed to dev](https://app.circleci.com/pipelines/github/Pocket/shareable-lists-api/498/workflows/dc76973e-97fc-443c-bf2a-6e5ec3226315).

## Tickets

- https://getpocket.atlassian.net/browse/OSL-266
