### PR TITLE
chore(seed data): [OSL-234] Add DB Seed Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,21 @@ Prepare Prisma:
 
 Start Docker container:
 
-- `docker-compose up --build -V`
+- `docker compose up --build -V`
 
-After Docker completes, you should be able to access the GraphQL playground at `http://localhost:4029`.
+Once all the Docker containers are up and running, you should be able to reach
+
+- the public API at `http://localhost:4029/`
+- the admin API at `http://localhost:4029/admin`
+
+
+Out of the box, the local installation doesn't have any actual data for you to fetch or manipulate through the API. To seed some sample data for your local dev environment, run
+
+```bash
+docker compose exec app npx prisma migrate reset
+```
+
+Note that the above command will not be adding to any data you may have added to the database through other means - it will do a complete reset AND apply the seed script located at `src/prisma/seed.ts`.
 
 ### Admin API Authorization
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "shareable-lists-api",
   "main": "dist/main.js",
+  "prisma": {
+    "seed": "ts-node --emit=false prisma/seed.ts"
+  },
   "scripts": {
     "build": "rm -rf dist && tsc",
     "watch": "tsc -w & nodemon",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,59 @@
+import { PilotUser, PrismaClient } from '@prisma/client';
+import {
+  createPilotUserHelper,
+  createShareableListHelper,
+  createShareableListItemHelper,
+} from '../src/test/helpers';
+import { faker } from '@faker-js/faker';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  // This seed script creates a number of shareable lists so that
+  // they can be looked up and moderated in the Curation Admin Tools frontend
+
+  // First we need a handful of users, though
+  const userIds: number[] = [12345, 34567, 45678, 78901];
+  const users: PilotUser[] = [];
+
+  for (const userId of userIds) {
+    const user = await createPilotUserHelper(prisma, { userId });
+    users.push(user);
+  }
+
+  // Now it's time to create some lists for these users
+  const listTitles: string[] = [];
+
+  for (let i = 0; i < 50; i++) {
+    listTitles.push(faker.lorem.sentence());
+  }
+
+  for (const title of listTitles) {
+    // get a random user from our array of users
+    const randomUser = users[Math.floor(Math.random() * users.length)];
+
+    // create a list for this random user
+    const list = await createShareableListHelper(prisma, {
+      title,
+      userId: randomUser.userId,
+    });
+
+    // add between 5 and 10 Pocket stories to this list
+    const numberOfStories = Math.floor(Math.random() * 5) + 5;
+
+    for (let i = 0; i <= numberOfStories; i++) {
+      await createShareableListItemHelper(prisma, { list }).catch(
+        console.error
+      );
+    }
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Goal

Unblock further development for admin tools

- Added a seed script that populates some data for local development using fictitious (e.g. 12345) user ids.

- Updated README with instructions on how to populate the local (or dev) environment with seed data.

- Updated README with details of both public and admin graphs where only the public one was mentioned previously.

## Tickets

- https://getpocket.atlassian.net/browse/OSL-234