### PR TITLE
chore(validation): [OSL-312] Remove emoji from list slugs

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -29,5 +29,10 @@ export default {
     release: process.env.GIT_SHA || '',
     environment: process.env.NODE_ENV || 'development',
   },
-  slugify: { lower: true, remove: /[*+~.()'"!:@]/g },
+  slugify: {
+    locale: 'en',
+    lower: true,
+    remove: /[*+~.()'"!:@]/g,
+    strict: true,
+  },
 };

--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -141,18 +141,18 @@ export async function updateShareableList(
     // run the title through the slugify function
     const slugifiedTitle = slugify(data.title ?? list.title, config.slugify);
 
-    // First check how many slugs containing the list title already exist in the db
-    const slugCount = await db.list.count({
-      where: {
-        userId,
-        slug: { contains: slugifiedTitle },
-      },
-    });
-
     // if title was made up entirely of characters that the slug cannot contain,
     // e.g. emojis, generate a neutral-sounding, short slug
     const preparedSlug =
       slugifiedTitle.length > 0 ? slugifiedTitle : 'shared-list';
+
+    // First check how many slugs containing the list title already exist in the db
+    const slugCount = await db.list.count({
+      where: {
+        userId,
+        slug: { contains: preparedSlug },
+      },
+    });
 
     // if there is at least 1 slug containing title of list to update,
     // append next consecutive # of slugCount to data.slug

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -843,6 +843,77 @@ describe('public mutations: ShareableList', () => {
       expect(updatedList.slug).to.equal('shared-list');
     });
 
+    it('should append consecutive numbers to slugs if user has multiple lists with all-emoji titles', async () => {
+      // create list 1
+      const firstList = await createShareableListHelper(db, {
+        title: '🌞 🌝 🌛 🌜 🌚 🌕 🌖 🌗 🌘 🌑 🌒 🌓 🌔 🌙',
+        userId: BigInt(headers.userId),
+      });
+      // make list 1 PUBLIC
+      const dataList1 = {
+        externalId: firstList.externalId,
+        status: ListStatus.PUBLIC,
+      };
+
+      let result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_SHAREABLE_LIST),
+          variables: { data: dataList1 },
+        });
+
+      // This mutation should not be cached, expect headers.cache-control = no-store
+      expect(result.headers['cache-control']).to.equal('no-store');
+      // There should be no errors
+      expect(result.body.errors).to.be.undefined;
+
+      // A result should be returned
+      expect(result.body.data.updateShareableList).not.to.be.null;
+
+      // Verify that the updates have taken place
+      const updatedList = result.body.data.updateShareableList;
+      expect(updatedList.status).to.equal(ListStatus.PUBLIC);
+      expect(updatedList.slug).not.to.be.empty;
+
+      // Is the slug the expected neutral name?
+      expect(updatedList.slug).to.equal('shared-list');
+
+      // Now create a new list with an all-emoji title, too
+      const secondList = await createShareableListHelper(db, {
+        title: '🍏 🍎 🍐 🍊 🍋 🍌 🍉 🍇 🍓 🫐 🍈 🍒 🍑 🥭 🍍',
+        userId: BigInt(headers.userId),
+      });
+      // make list 2 PUBLIC
+      const dataList2 = {
+        externalId: secondList.externalId,
+        status: ListStatus.PUBLIC,
+      };
+
+      result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_SHAREABLE_LIST),
+          variables: { data: dataList2 },
+        });
+
+      // This mutation should not be cached, expect headers.cache-control = no-store
+      expect(result.headers['cache-control']).to.equal('no-store');
+      // There should be no errors
+      expect(result.body.errors).to.be.undefined;
+
+      // A result should be returned
+      expect(result.body.data.updateShareableList).not.to.be.null;
+
+      // Verify that the updates have taken place
+      const updatedList2 = result.body.data.updateShareableList;
+      expect(updatedList2.status).to.equal(ListStatus.PUBLIC);
+      expect(updatedList2.title).to.equal(secondList.title);
+      // Expect the slug to equal shared-list-2
+      expect(updatedList2.slug).to.equal('shared-list-2');
+    });
+
     it('should generate two identical slugs but for two different users', async () => {
       // create list 1
       const firstList = await createShareableListHelper(db, {


### PR DESCRIPTION
## Goal

Improve slugs for shared lists.

- Updated `slugify` config to remove all characters that don't exist in the package's char map: https://github.com/simov/slugify/blob/master/config/charmap.json

- Added a neutral slug text for cases when list title is composed entirely of emoji or other characters that would be removed during the slugifying process: `shared-list`.

- Added two new integration tests to cover updated functionality.



## Tickets

https://getpocket.atlassian.net/browse/OSL-312
