### PR TITLE
chore(errors): Improve error message copy for admin query

### DIFF
--- a/src/admin/resolvers/queries/ShareableList.ts
+++ b/src/admin/resolvers/queries/ShareableList.ts
@@ -24,7 +24,7 @@ export async function searchShareableList(
   const list = await dbSearchShareableList(db, externalId);
 
   if (!list) {
-    throw new NotFoundError(externalId);
+    throw new NotFoundError(`List ${externalId} cannot be found.`);
   }
 
   return list;


### PR DESCRIPTION
## Goal

Improve the error message for `searchShareableList` query - initially it was set up in a not-so-UX-friendly way and showed up as `[GraphQL error]: Error - Not Found: abcd123`. This is related to OSL - 167 (the frontend tools moderation ticket). 
