### PR TITLE
OSL-319: adding moderationDetails to admin schema and prisma, adding HideShareableListModerationReasonOptions enum, updating Snowplow schema, updating tests

### DIFF
--- a/prisma/migrations/20230327171441_add_moderation_detail/migration.sql
+++ b/prisma/migrations/20230327171441_add_moderation_detail/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `List` ADD COLUMN `moderationDetails` TEXT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,20 +21,21 @@ enum ModerationStatus {
 model List {
   // *** Table fields ***
   // Prisma needs an integer ID to make relationships between tables
-  id               BigInt           @id @default(autoincrement())
+  id                BigInt           @id @default(autoincrement())
   // This is our public-facing ID for use in Admin Tools and Snowplow event reporting
-  externalId       String           @default(uuid()) @db.VarChar(255)
+  externalId        String           @default(uuid()) @db.VarChar(255)
   // This is the Pocket ID. Sourced externally from a mutation input
-  userId           BigInt
-  slug             String?          @db.VarChar(300)
-  title            String           @db.VarChar(300)
-  description      String?          @db.Text
-  status           ListStatus       @default(PRIVATE)
-  moderationStatus ModerationStatus @default(VISIBLE)
-  moderatedBy      String?          @db.VarChar(255)
-  moderationReason String?          @db.Text
-  createdAt        DateTime         @default(now()) @db.DateTime(0)
-  updatedAt        DateTime         @updatedAt
+  userId            BigInt
+  slug              String?          @db.VarChar(300)
+  title             String           @db.VarChar(300)
+  description       String?          @db.Text
+  status            ListStatus       @default(PRIVATE)
+  moderationStatus  ModerationStatus @default(VISIBLE)
+  moderatedBy       String?          @db.VarChar(255)
+  moderationReason  String?          @db.Text
+  moderationDetails String?          @db.Text
+  createdAt         DateTime         @default(now()) @db.DateTime(0)
+  updatedAt         DateTime         @updatedAt
 
   // *** Associated models ***
   listItems ListItem[]

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -1,55 +1,82 @@
+enum HiddenShareableListModerationReason {
+  ABUSIVE_BEHAVIOR
+  POSTING_PRIVATE_INFORMATION
+  HATE_SPEECH
+  MISLEADING_INFORMATION
+  ADULT_SEXUAL_CONTENT
+  CSAM_IMAGES
+  CSAM_SOLICITATION
+  ILLEGAL_GOODS_AND_SERVICES
+  VIOLENCE_AND_GORE
+  INSTRUCTIONS_FOR_VIOLENCE
+  INCITEMENT_TO_VIOLENCE
+  SELF_HARM
+  TERRORISM
+  COPYRIGHT
+  TRADEMARK
+  COUNTERFEIT
+  SPAM
+  FRAUD
+  MALWARE
+  PHISHING
+}
+
 type ShareableListComplete implements ShareableListInterface {
-    """
-    A unique string identifier in UUID format.
-    """
-    externalId: ID!
-    """
-    The user who created this shareable list.
-    """
-    user: User!
-    """
-    A URL-ready identifier of the list. Generated from the title
-    of the list when it's first made public. Unique per user.
-    """
-    slug: String
-    """
-    The title of the list. Provided by the Pocket user.
-    """
-    title: String!
-    """
-    Optional text description of a Shareable List. Provided by the Pocket user.
-    """
-    description: String
-    """
-    The status of the list. Defaults to PRIVATE.
-    """
-    status: ShareableListStatus!
-    """
-    The moderation status of the list. Defaults to VISIBLE.
-    """
-    moderationStatus: ShareableListModerationStatus!
-    """
-    The timestamp of when the list was created by its owner.
-    """
-    createdAt: ISOString!
-    """
-    The timestamp of when the list was last updated by its owner
-    or a member of the moderation team.
-    """
-    updatedAt: ISOString!
-    """
-    Pocket Saves that have been added to this list by the Pocket user.
-    """
-    listItems: [ShareableListItem!]!
-    """
-    The LDAP username of the moderator who took down a list
-    that violates the Pocket content moderation policy.
-    """
-    moderatedBy: String
-    """
-    The reason why the moderator took down the list.
-    """
-    moderationReason: String
+  """
+  A unique string identifier in UUID format.
+  """
+  externalId: ID!
+  """
+  The user who created this shareable list.
+  """
+  user: User!
+  """
+  A URL-ready identifier of the list. Generated from the title
+  of the list when it's first made public. Unique per user.
+  """
+  slug: String
+  """
+  The title of the list. Provided by the Pocket user.
+  """
+  title: String!
+  """
+  Optional text description of a Shareable List. Provided by the Pocket user.
+  """
+  description: String
+  """
+  The status of the list. Defaults to PRIVATE.
+  """
+  status: ShareableListStatus!
+  """
+  The moderation status of the list. Defaults to VISIBLE.
+  """
+  moderationStatus: ShareableListModerationStatus!
+  """
+  The timestamp of when the list was created by its owner.
+  """
+  createdAt: ISOString!
+  """
+  The timestamp of when the list was last updated by its owner
+  or a member of the moderation team.
+  """
+  updatedAt: ISOString!
+  """
+  Pocket Saves that have been added to this list by the Pocket user.
+  """
+  listItems: [ShareableListItem!]!
+  """
+  The LDAP username of the moderator who took down a list
+  that violates the Pocket content moderation policy.
+  """
+  moderatedBy: String
+  """
+  The reason why the moderator took down the list.
+  """
+  moderationReason: HiddenShareableListModerationReason
+  """
+  The optional details why the list was moderated.
+  """
+  moderationDetails: String
 }
 
 type Query {
@@ -65,12 +92,15 @@ Input data for removing (moderating) a ShareableList
 input ModerateShareableListInput {
   externalId: ID!
   moderationStatus: ShareableListModerationStatus!
-  moderationReason: String!
+  moderationReason: HiddenShareableListModerationReason!
+  moderationDetails: String
 }
 
 type Mutation {
-	"""
-	Removes (moderates) a Shareable List.
-	"""
-	moderateShareableList(data: ModerateShareableListInput!): ShareableListComplete
+  """
+  Removes (moderates) a Shareable List.
+  """
+  moderateShareableList(
+    data: ModerateShareableListInput!
+  ): ShareableListComplete
 }

--- a/src/admin/resolvers/fragments.gql.ts
+++ b/src/admin/resolvers/fragments.gql.ts
@@ -13,6 +13,7 @@ export const ShareableListCompleteProps = gql`
     updatedAt
     moderatedBy
     moderationReason
+    moderationDetails
     listItems {
       ...ShareableListItemPublicProps
     }

--- a/src/admin/resolvers/mutations/ShareableList.integration.ts
+++ b/src/admin/resolvers/mutations/ShareableList.integration.ts
@@ -20,6 +20,7 @@ import {
   READONLY,
 } from '../../../shared/constants';
 import { MODERATE_SHAREABLE_LIST } from './sample-mutations.gql';
+import { HideShareableListModerationReasonOptions } from '../../../database/types';
 
 const validHeaders = {
   name: 'Lee Moderator',
@@ -61,7 +62,7 @@ describe('admin mutations: ShareableList', () => {
       const data = {
         externalId: 'xid',
         moderationStatus: 'HIDDEN',
-        moderationReason: 'Some reason',
+        moderationReason: HideShareableListModerationReasonOptions.FRAUD,
       };
 
       const result = await request(app)
@@ -81,7 +82,7 @@ describe('admin mutations: ShareableList', () => {
       const data = {
         externalId: 'xid',
         moderationStatus: 'HIDDEN',
-        moderationReason: 'Some reason',
+        moderationReason: HideShareableListModerationReasonOptions.FRAUD,
       };
       const result = await request(app)
         .post(graphQLUrl)
@@ -105,7 +106,8 @@ describe('admin mutations: ShareableList', () => {
       const data = {
         externalId: theList.externalId,
         moderationStatus: 'HIDDEN',
-        moderationReason: 'Some reason',
+        moderationReason: HideShareableListModerationReasonOptions.FRAUD,
+        moderationDetails: 'making list hidden',
       };
       const result = await request(app)
         .post(graphQLUrl)
@@ -121,6 +123,7 @@ describe('admin mutations: ShareableList', () => {
       expect(moderatedList.externalId).to.equal(theList.externalId);
       expect(moderatedList.moderationStatus).to.equal(data.moderationStatus);
       expect(moderatedList.moderationReason).to.equal(data.moderationReason);
+      expect(moderatedList.moderationDetails).to.equal(data.moderationDetails);
     });
     it('can make a hidden list visible', async () => {
       const theList = await createShareableListHelper(db, {
@@ -132,7 +135,10 @@ describe('admin mutations: ShareableList', () => {
       const data = {
         externalId: theList.externalId,
         moderationStatus: 'VISIBLE',
-        moderationReason: 'Some reason',
+        // we don't have a list of reasons for making a list visible, so pass
+        // HideShareableListModerationReasonOptions enum val as this field is required
+        moderationReason: HideShareableListModerationReasonOptions.FRAUD,
+        moderationDetails: 'making list visible',
       };
       const result = await request(app)
         .post(graphQLUrl)
@@ -148,8 +154,9 @@ describe('admin mutations: ShareableList', () => {
       expect(moderatedList.externalId).to.equal(theList.externalId);
       expect(moderatedList.moderationStatus).to.equal(data.moderationStatus);
       expect(moderatedList.moderationReason).to.equal(data.moderationReason);
+      expect(moderatedList.moderationDetails).to.equal(data.moderationDetails);
     });
-    it('needs a reason', async () => {
+    it('moderationDetails is optional', async () => {
       const theList = await createShareableListHelper(db, {
         userId: 12345,
         title: 'Moderate this list',
@@ -157,8 +164,8 @@ describe('admin mutations: ShareableList', () => {
       });
       const data = {
         externalId: theList.externalId,
-        moderationStatus: 'VISIBLE',
-        moderationReason: '',
+        moderationStatus: 'HIDDEN',
+        moderationReason: HideShareableListModerationReasonOptions.FRAUD,
       };
       const result = await request(app)
         .post(graphQLUrl)
@@ -169,11 +176,12 @@ describe('admin mutations: ShareableList', () => {
             data: data,
           },
         });
-      expect(result.body.data.moderateShareableList).to.be.null;
-      expect(result.body.errors[0].message).to.equal(
-        MODERATION_REASON_REQUIRED_ERROR
-      );
-      expect(result.body.errors[0].extensions.code).to.equal('BAD_USER_INPUT');
+      const moderatedList = result.body.data.moderateShareableList;
+      expect(moderatedList).to.not.be.null;
+      expect(moderatedList.externalId).to.equal(theList.externalId);
+      expect(moderatedList.moderationStatus).to.equal(data.moderationStatus);
+      expect(moderatedList.moderationReason).to.equal(data.moderationReason);
+      expect(moderatedList.moderationDetails).to.be.null;
     });
   });
 });

--- a/src/admin/resolvers/mutations/ShareableList.ts
+++ b/src/admin/resolvers/mutations/ShareableList.ts
@@ -29,9 +29,8 @@ export async function moderateShareableList(
     throw new ForbiddenError(ACCESS_DENIED_ERROR);
   }
   data.moderatedBy = authenticatedUser.username;
-  data.moderationReason = data.moderationReason.trim();
-  if (data.moderationReason.length === 0) {
-    throw new UserInputError(MODERATION_REASON_REQUIRED_ERROR);
+  if (data.moderationDetails) {
+    data.moderationDetails = data.moderationDetails.trim();
   }
   return await dbModerateShareableList(db, data);
 }

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -12,10 +12,33 @@ export type ShareableListItem = Omit<ListItem, 'id' | 'externalId' | 'listId'>;
  */
 export type ShareableList = Omit<
   List,
-  'id' | 'moderatedBy' | 'moderationReason'
+  'id' | 'moderatedBy' | 'moderationReason' | 'moderationDetails'
 > & {
   listItems?: ShareableListItem[];
 };
+
+export enum HideShareableListModerationReasonOptions {
+  ABUSIVE_BEHAVIOR = 'ABUSIVE_BEHAVIOR',
+  POSTING_PRIVATE_INFORMATION = 'POSTING_PRIVATE_INFORMATION',
+  HATE_SPEECH = 'HATE_SPEECH',
+  MISLEADING_INFORMATION = 'MISLEADING_INFORMATION',
+  ADULT_SEXUAL_CONTENT = 'ADULT_SEXUAL_CONTENT',
+  CSAM_IMAGES = 'CSAM_IMAGES',
+  CSAM_SOLICITATION = 'CSAM_SOLICITATION',
+  ILLEGAL_GOODS_AND_SERVICES = 'ILLEGAL_GOODS_AND_SERVICES',
+  VIOLENCE_AND_GORE = 'VIOLENCE_AND_GORE',
+  INSTRUCTIONS_FOR_VIOLENCE = 'INSTRUCTIONS_FOR_VIOLENCE',
+  INCITEMENT_TO_VIOLENCE = 'INCITEMENT_TO_VIOLENCE',
+  SELF_HARM = 'SELF_HARM',
+  TERRORISM = 'TERRORISM',
+  COPYRIGHT = 'COPYRIGHT',
+  TRADEMARK = 'TRADEMARK',
+  COUNTERFEIT = 'COUNTERFEIT',
+  SPAM = 'SPAM',
+  FRAUD = 'FRAUD',
+  MALWARE = 'MALWARE',
+  PHISHING = 'PHISHING',
+}
 
 /**
  * This is the shape of a shareable list object on the Admin Pocket Graph.
@@ -43,7 +66,8 @@ export type UpdateShareableListInput = {
 export type ModerateShareableListInput = {
   externalId: string;
   moderationStatus: ModerationStatus;
-  moderationReason: string;
+  moderationReason: HideShareableListModerationReasonOptions;
+  moderationDetails?: string;
   // not in the schema, copied from the request user data when updating
   moderatedBy: string;
 };

--- a/src/snowplow/events.spec.ts
+++ b/src/snowplow/events.spec.ts
@@ -3,7 +3,11 @@ import { expect } from 'chai';
 import * as Sentry from '@sentry/node';
 import { EventBridgeClient } from '@aws-sdk/client-eventbridge';
 import { ListStatus, ModerationStatus } from '@prisma/client';
-import { ShareableListComplete, ShareableListItem } from '../database/types';
+import {
+  HideShareableListModerationReasonOptions,
+  ShareableListComplete,
+  ShareableListItem,
+} from '../database/types';
 import {
   generateShareableListEventBridgePayload,
   generateShareableListItemEventBridgePayload,
@@ -29,6 +33,7 @@ describe('Snowplow event helpers', () => {
     moderationStatus: ModerationStatus.VISIBLE,
     moderatedBy: null,
     moderationReason: null,
+    moderationDetails: null,
     createdAt: new Date('2023-01-01 10:10:10'),
     updatedAt: new Date('2023-01-01 10:10:10'),
   };
@@ -185,6 +190,9 @@ describe('Snowplow event helpers', () => {
     // SHAREABLE_LIST_HIDDEN
     // update some properties
     shareableList.moderationStatus = ModerationStatus.HIDDEN;
+    shareableList.moderationReason =
+      HideShareableListModerationReasonOptions.SPAM;
+    shareableList.moderationDetails = 'more details here';
     shareableList.updatedAt = new Date('2023-02-03 05:15:43');
     newUpdatedAt = shareableList.updatedAt;
     payload = await generateShareableListEventBridgePayload(
@@ -193,13 +201,21 @@ describe('Snowplow event helpers', () => {
     );
     // shareableList obj must not be null
     expect(payload.shareableList).to.not.be.null;
-    // check that the payload event type is for shareable-list-unpublished
+    // check that the payload event type is for shareable-list-hidden
     expect(payload.eventType).to.equal(
       EventBridgeEventType.SHAREABLE_LIST_HIDDEN
     );
     // check that moderation_status was updated to HIDDEN
     expect(payload.shareableList.moderation_status).to.equal(
       ModerationStatus.HIDDEN
+    );
+    // check that moderation_reason exists
+    expect(payload.shareableList.moderation_reason).to.equal(
+      HideShareableListModerationReasonOptions.SPAM
+    );
+    // check that moderation_details exists
+    expect(payload.shareableList.moderation_details).to.equal(
+      'more details here'
     );
     // updatedAt -> updated_at in seconds
     expect(payload.shareableList.updated_at).to.equal(

--- a/src/snowplow/events.ts
+++ b/src/snowplow/events.ts
@@ -37,6 +37,9 @@ function transformAPIShareableListToSnowplowShareableList(
     moderation_reason: shareableList.moderationReason
       ? shareableList.moderationReason
       : undefined,
+    moderation_details: shareableList.moderationDetails
+      ? shareableList.moderationDetails
+      : undefined,
     created_at: Math.floor(shareableList.createdAt.getTime() / 1000),
     updated_at: shareableList.updatedAt
       ? Math.floor(shareableList.updatedAt.getTime() / 1000)

--- a/src/snowplow/types.ts
+++ b/src/snowplow/types.ts
@@ -43,6 +43,7 @@ export type SnowplowShareableList = {
   moderation_status: ModerationStatus;
   moderated_by?: string;
   moderation_reason?: string;
+  moderation_details?: string;
   created_at: number; // snowplow schema requires this field in seconds
   updated_at?: number; // snowplow schema requires this field in seconds
 };


### PR DESCRIPTION
## Goal

Lets not merge this PR until [https://getpocket.atlassian.net/browse/OSL-322](https://getpocket.atlassian.net/browse/OSL-322) has been complete.

`moderationReason` is now a list of reasons why to take down a list. Created `HideShareableListModerationReasonOptions` enum in the Typescript/GraphQL schema to keep track. Adjusted this in the admin schema and introduced new field `moderationDetails` to store extra notes about why the list was moderated. Updated the Snowplow types as well, and updated tests related to this change. 

## Todos

- [ ] deploy to dev

## Tickets

- Link to JIRA tickets

