### PR TITLE
chore(test data): Update seed script to make lists public

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -39,13 +39,15 @@ async function main() {
       userId: randomUser.userId,
     });
 
-    // turn it public so that it obtains a slug - this seed data
-    // is created for the benefit of testing the admin tools after all
-    await updateShareableList(
-      prisma,
-      { externalId: list.externalId, status: ListStatus.PUBLIC },
-      randomUser.userId
-    );
+    // Turn some lists public so that the status changes and a slug is generated.
+    // This seed data is created for the benefit of testing the admin tools after all.
+    if (Math.random() > 0.5) {
+      await updateShareableList(
+        prisma,
+        { externalId: list.externalId, status: ListStatus.PUBLIC },
+        randomUser.userId
+      );
+    }
 
     // add between 5 and 10 Pocket stories to this list
     const numberOfStories = Math.floor(Math.random() * 5) + 5;

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,10 +1,11 @@
-import { PilotUser, PrismaClient } from '@prisma/client';
+import { ListStatus, PilotUser, PrismaClient } from '@prisma/client';
 import {
   createPilotUserHelper,
   createShareableListHelper,
   createShareableListItemHelper,
 } from '../src/test/helpers';
 import { faker } from '@faker-js/faker';
+import { updateShareableList } from '../src/database/mutations';
 
 const prisma = new PrismaClient();
 
@@ -37,6 +38,14 @@ async function main() {
       title,
       userId: randomUser.userId,
     });
+
+    // turn it public so that it obtains a slug - this seed data
+    // is created for the benefit of testing the admin tools after all
+    await updateShareableList(
+      prisma,
+      { externalId: list.externalId, status: ListStatus.PUBLIC },
+      randomUser.userId
+    );
 
     // add between 5 and 10 Pocket stories to this list
     const numberOfStories = Math.floor(Math.random() * 5) + 5;

--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -128,7 +128,7 @@ export async function updateShareableList(
     }
   }
 
-  // check list title and descipriotn length
+  // check list title and description length
   shareableListTitleDescriptionValidation(
     data.title ? data.title : null,
     data.description ? data.description : null


### PR DESCRIPTION
## Goal

Improve ease of Admin Tools development for Shareable Lists.

- Update seed script to make lists public

- And have slugs generated for them so that they can be used in Dev Curation Admin Tools for testing and development

## Tickets

 - not ticketed, but related to OSL - 167
