### PR TITLE
refactor(itemId): change itemId to ID (string) from Float

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -119,7 +119,7 @@ Input data for creating a Shareable List Item.
 """
 input CreateShareableListItemInput {
   listExternalId: ID!
-  itemId: Float
+  itemId: ID
   url: Url!
   title: String
   excerpt: String
@@ -133,7 +133,7 @@ input CreateShareableListItemInput {
 Input data for creating a Shareable List Item during Shareable List creation.
 """
 input CreateShareableListItemWithList {
-  itemId: Float
+  itemId: ID
   url: Url!
   title: String
   excerpt: String

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -63,7 +63,7 @@ type ShareableListItem {
   """
   The Parser Item ID.
   """
-  itemId: Float
+  itemId: ID
   """
   The URL of the story saved to a list.
   """

--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -19,6 +19,7 @@ import {
 } from '../../shared/constants';
 import { getShareableList } from '../queries';
 import config from '../../config';
+import { validateItemId } from '../../public/resolvers/utils';
 import { sendEventHelper } from '../../snowplow/events';
 import { EventBridgeEventType } from '../../snowplow/types';
 
@@ -36,6 +37,19 @@ export async function createShareableList(
 ): Promise<ShareableList> {
   let listItemData;
 
+  // check if listItem data is passed
+  if (listData.listItem) {
+    // make sure the itemId is valid - if not, fail the entire operation early
+    //
+    // this is required as itemId must be a string at the API level, but is
+    // actually a number in the db (legacy problems)
+    validateItemId(listData.listItem.itemId);
+
+    listItemData = listData.listItem;
+    //remove it from listData so that we can create the ShareableList first
+    delete listData.listItem;
+  }
+
   // check if the title already exists for this user
   const titleExists = await db.list.count({
     where: { title: listData.title, userId: userId },
@@ -52,13 +66,6 @@ export async function createShareableList(
     listData.title,
     listData.description ? listData.description : null
   );
-
-  // check if listItem data is passed
-  if (listData.listItem) {
-    listItemData = listData.listItem;
-    //remove it from listData so that we can create the ShareableList first
-    delete listData.listItem;
-  }
 
   // create ShareableList in db
   const list: ShareableList = await db.list.create({

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -74,7 +74,7 @@ export type ModerateShareableListInput = {
 
 export type CreateShareableListItemInput = {
   listExternalId: string;
-  itemId?: number;
+  itemId?: string;
   url: string;
   title?: string;
   excerpt?: string;

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -169,6 +169,41 @@ describe('public mutations: ShareableList', () => {
       expect(list.listItems.length).to.equal(0);
     });
 
+    it('should not create a new List with a ListItem with an invalid itemId', async () => {
+      const title = 'My list to share<script>alert("Hello World!")</script>';
+      const listData: CreateShareableListInput = {
+        title: title,
+        description: faker.lorem.sentences(2),
+      };
+
+      const listItemData = {
+        itemId: '378asdf9538749', // invalid!
+        url: 'https://www.test.com/this-is-a-story',
+        title: 'A story is a story',
+        excerpt: '<blink>The best story ever told</blink>',
+        imageUrl: 'https://www.test.com/thumbnail.jpg',
+        publisher: 'The London Times',
+        authors: 'Charles Dickens, Mark Twain',
+        sortOrder: 10,
+      };
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(CREATE_SHAREABLE_LIST),
+          variables: { listData, listItemData },
+        });
+
+      const errors = result.body.errors;
+
+      expect(errors.length).to.equal(1);
+      expect(errors[0].extensions.code).to.equal('BAD_USER_INPUT');
+      expect(errors[0].message).to.equal(
+        `${listItemData.itemId} is an invalid itemId`
+      );
+    });
+
     it('should create a new List with a ListItem', async () => {
       const title = 'My list to share<script>alert("Hello World!")</script>';
       const listData: CreateShareableListInput = {
@@ -177,7 +212,7 @@ describe('public mutations: ShareableList', () => {
       };
 
       const listItemData = {
-        itemId: 3789538749,
+        itemId: '3789538749',
         url: 'https://www.test.com/this-is-a-story',
         title: 'A story is a story',
         excerpt: '<blink>The best story ever told</blink>',

--- a/src/public/resolvers/mutations/ShareableListItem.integration.ts
+++ b/src/public/resolvers/mutations/ShareableListItem.integration.ts
@@ -87,7 +87,7 @@ describe('public mutations: ShareableListItem', () => {
     it('should not create a new item for a user not in the pilot', async () => {
       const data: CreateShareableListItemInput = {
         listExternalId: 'this-list-does-not-even-exist',
-        itemId: 1,
+        itemId: '1',
         url: 'https://getpocket.com/discover',
         sortOrder: 1,
       };
@@ -111,7 +111,7 @@ describe('public mutations: ShareableListItem', () => {
     it("should not create a new item for a list that doesn't exist", async () => {
       const data: CreateShareableListItemInput = {
         listExternalId: 'this-list-does-not-even-exist',
-        itemId: 1,
+        itemId: '1',
         url: 'https://getpocket.com/discover',
         sortOrder: 1,
       };
@@ -140,7 +140,7 @@ describe('public mutations: ShareableListItem', () => {
 
       const data: CreateShareableListItemInput = {
         listExternalId: hiddenList.externalId,
-        itemId: 1,
+        itemId: '1',
         url: 'https://getpocket.com/discover',
         sortOrder: 5,
       };
@@ -163,7 +163,7 @@ describe('public mutations: ShareableListItem', () => {
     it('should not create a list item in a list that belongs to another user', async () => {
       const data: CreateShareableListItemInput = {
         listExternalId: list.externalId,
-        itemId: 1,
+        itemId: '1',
         url: 'https://www.test.com/this-is-a-story',
         title: 'This Story Is Trying to Sneak In',
         sortOrder: 20,
@@ -185,10 +185,38 @@ describe('public mutations: ShareableListItem', () => {
       expect(result.body.errors[0].extensions.code).to.equal('NOT_FOUND');
     });
 
+    it('should not create a new list item with an invalid itemId', async () => {
+      const data: CreateShareableListItemInput = {
+        listExternalId: list.externalId,
+        itemId: '383asdf4701731',
+        url: 'https://www.test.com/this-is-a-story',
+        title: 'A story is a story',
+        excerpt: '<blink>The best story ever told</blink>',
+        imageUrl: 'https://www.test.com/thumbnail.jpg',
+        publisher: 'The London Times',
+        authors: 'Charles Dickens, Mark Twain',
+        sortOrder: 10,
+      };
+
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(CREATE_SHAREABLE_LIST_ITEM),
+          variables: { data },
+        });
+
+      // And a "Not found" error
+      expect(result.body.errors[0].extensions.code).to.equal('BAD_USER_INPUT');
+      expect(result.body.errors[0].message).to.equal(
+        `${data.itemId} is an invalid itemId`
+      );
+    });
+
     it('should create a new list item', async () => {
       const data: CreateShareableListItemInput = {
         listExternalId: list.externalId,
-        itemId: 3789538749,
+        itemId: '3834701731',
         url: 'https://www.test.com/this-is-a-story',
         title: 'A story is a story',
         excerpt: '<blink>The best story ever told</blink>',
@@ -216,7 +244,7 @@ describe('public mutations: ShareableListItem', () => {
       // Assert that all props are returned
       const listItem = result.body.data.createShareableListItem;
       expect(listItem.externalId).not.to.be.empty;
-      expect(listItem.itemId).to.equal(3789538749);
+      expect(listItem.itemId).to.equal(data.itemId);
       expect(listItem.url).to.equal(data.url);
       expect(listItem.title).to.equal(data.title);
       expect(listItem.excerpt).to.equal(
@@ -240,7 +268,7 @@ describe('public mutations: ShareableListItem', () => {
 
       const data: CreateShareableListItemInput = {
         listExternalId: list.externalId,
-        itemId: 1,
+        itemId: '1',
         url: 'https://www.test.com/duplicate-url',
         sortOrder: 5,
       };
@@ -276,7 +304,7 @@ describe('public mutations: ShareableListItem', () => {
 
       const data: CreateShareableListItemInput = {
         listExternalId: list.externalId,
-        itemId: 3789538749,
+        itemId: '3789538749',
         url: 'https://www.test.com/another-duplicate-url',
         title: 'A story is a story',
         excerpt: 'The best story ever told',
@@ -304,7 +332,7 @@ describe('public mutations: ShareableListItem', () => {
       // Assert that all props are returned
       const listItem = result.body.data.createShareableListItem;
       expect(listItem.externalId).not.to.be.empty;
-      expect(listItem.itemId).to.equal(3789538749);
+      expect(listItem.itemId).to.equal(data.itemId);
       expect(listItem.url).to.equal(data.url);
       expect(listItem.title).to.equal(data.title);
       expect(listItem.excerpt).to.equal(data.excerpt);

--- a/src/public/resolvers/utils.spec.ts
+++ b/src/public/resolvers/utils.spec.ts
@@ -1,11 +1,53 @@
 import { expect } from 'chai';
+
+import { UserInputError } from '@pocket-tools/apollo-utils';
+
 import {
   CreateShareableListInput,
   CreateShareableListItemInput,
 } from '../../database/types';
-import { sanitizeMutationInput } from './utils';
+import { sanitizeMutationInput, validateItemId } from './utils';
 
 describe('utility functions', () => {
+  describe('validateItemId', () => {
+    it('does not throw an error for a missing itemId', () => {
+      expect(() => {
+        validateItemId(null);
+      }).not.to.throw();
+
+      expect(() => {
+        validateItemId(undefined);
+      }).not.to.throw();
+
+      expect(() => {
+        validateItemId();
+      }).not.to.throw();
+    });
+
+    it('throws an error for a non-numeric itemId', () => {
+      expect(() => {
+        validateItemId('1234asdf5678');
+      }).to.throw(UserInputError);
+
+      expect(() => {
+        validateItemId('asdf12345678');
+      }).to.throw(UserInputError);
+
+      expect(() => {
+        validateItemId('12345678asdf');
+      }).to.throw(UserInputError);
+
+      expect(() => {
+        validateItemId('asdf');
+      }).to.throw(UserInputError);
+    });
+
+    it('does not throw for a numeric itemId', () => {
+      expect(() => {
+        validateItemId('123456789');
+      }).not.to.throw();
+    });
+  });
   describe('xssifyMutationInput', () => {
     it('transforms strings in a mutation input object', () => {
       const input: CreateShareableListInput = {
@@ -25,7 +67,7 @@ describe('utility functions', () => {
     it('returns numeric values as-is in a mutation input object', () => {
       const input: CreateShareableListItemInput = {
         listExternalId: '123-abc',
-        itemId: 456789,
+        itemId: '456789',
         url: 'https://www.test.com/story',
         title: 'This is a test title',
         excerpt: 'An excerpt sounds like a good thing to have',

--- a/src/public/resolvers/utils.ts
+++ b/src/public/resolvers/utils.ts
@@ -1,7 +1,7 @@
 import xss from 'xss';
 
 import { PrismaClient } from '@prisma/client';
-import { ForbiddenError } from '@pocket-tools/apollo-utils';
+import { ForbiddenError, UserInputError } from '@pocket-tools/apollo-utils';
 
 import { IPublicContext } from '../context';
 import { ACCESS_DENIED_ERROR } from '../../shared/constants';
@@ -69,4 +69,25 @@ export async function validateUserId(
   }
 
   return userId;
+}
+
+/**
+ * throws an error if the string value of itemId is not numeric
+ *
+ * itemId values must be strings when coming in from clients due to legacy
+ * issues, yet needs to be stored as a number to match the canonical item
+ * database table.
+ *
+ * @param itemId string | undefined
+ * @returns void
+ */
+export function validateItemId(itemId?: string) {
+  if (!itemId) return;
+
+  if (
+    itemId &&
+    (isNaN(itemId as unknown as number) || isNaN(parseInt(itemId)))
+  ) {
+    throw new UserInputError(`${itemId} is an invalid itemId`);
+  }
 }


### PR DESCRIPTION
## Goal

change `itemId` in the API to an `ID`.

- necessary to support clients, who treat itemId as string due to legacy issues

## Tickets

- https://getpocket.atlassian.net/browse/OSL-333

## Implementation Decisions

- failing the entire operation when trying to create a list w/a list item with an invalid id. this seems like the easiest route, as it's not straightforward to create the list successfully but fail the list item. would be happy to find a better way here (create the list and return that data while also returning the error for the list item), but this is an edge case that i'm not sure needs more time devoted to it.