### PR TITLE
fix(itemId): fix resolving when itemId is null in the db

### DIFF
--- a/src/database/mutations/ShareableListItem.ts
+++ b/src/database/mutations/ShareableListItem.ts
@@ -57,7 +57,13 @@ export async function createShareableListItem(
 
   const input = {
     // coerce itemId to a number to conform to db schema
-    itemId: parseInt(data.itemId),
+    // if no itemId is set, send null. accepting null here should only
+    // occur in test scenarios, as we need to be able to mock list items that
+    // are missing itemId. as of this writing, the schema requires itemId.
+    // once we backfill old data missing itemId, we can revert this to:
+    // itemId: parseInt(data.itemId)
+    // https://getpocket.atlassian.net/browse/OSL-338
+    itemId: data.itemId ? parseInt(data.itemId) : null,
     url: data.url,
     title: data.title ?? undefined,
     excerpt: data.excerpt ?? undefined,

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -386,8 +386,11 @@ describe('public queries: ShareableList', () => {
         moderationStatus: ModerationStatus.VISIBLE,
       });
 
-      // Create a couple of list items
-      await createShareableListItemHelper(db, { list: newList });
+      // Create a couple of list items, the first is missing an itemId (to
+      // mimic old data where itemId was not captured).
+      // once we backfill old data, we can remove the itemId: 0 below.
+      // https://getpocket.atlassian.net/browse/OSL-338
+      await createShareableListItemHelper(db, { list: newList, itemId: 0 });
       await createShareableListItemHelper(db, { list: newList });
 
       // Run the query we're testing

--- a/src/shared/resolvers/fields/PrismaBigInt.ts
+++ b/src/shared/resolvers/fields/PrismaBigInt.ts
@@ -14,9 +14,14 @@ export const PrismaBigIntResolver = (parent, args, context, info) => {
 };
 
 function parseFieldToInt(field: string) {
+  // as the schema now requires returning a value even when the db is missing
+  // an itemId, we need to return an empty string (and not null)
+  // once we backfill, if !field, we should error to sentry.
+  // https://getpocket.atlassian.net/browse/OSL-338
   if (!field) {
-    return null;
+    return '';
   }
   const parsedField = parseInt(field);
-  return isNaN(parsedField) ? null : parsedField;
+  // same here - if the parsed value is NaN, fall back to an empty string
+  return isNaN(parsedField) ? '' : parsedField;
 }

--- a/src/test/helpers/createShareableListItemHelper.ts
+++ b/src/test/helpers/createShareableListItemHelper.ts
@@ -27,7 +27,12 @@ export async function createShareableListItemHelper(
 ): Promise<ListItem> {
   const input = {
     listId: data.list.id,
-    itemId: data.itemId ?? faker.datatype.number(),
+    // if 0 was explicitly sent, do NOT include an itemId. this is to mimic old
+    // data that's missing itemId in the db. once we've backfilled the old data
+    // we can revert this conditional to:
+    // itemId: data.itemId ?? faker.datatype.number()
+    // https://getpocket.atlassian.net/browse/OSL-338
+    itemId: data.itemId === 0 ? null : faker.datatype.number(),
     url: data.url ?? `${faker.internet.url()}/${faker.lorem.slug(5)}`,
     title: data.title ?? faker.random.words(5),
     excerpt: data.excerpt ?? faker.lorem.sentences(2),


### PR DESCRIPTION
## Goal

fix resolving when itemId is null in the db.

[successfully pushed to dev](https://app.circleci.com/pipelines/github/Pocket/shareable-lists-api/818/workflows/6f32e29e-11be-43a4-9e45-3522b3ec699a) and verified with an `itemId = null` scenario.

## Tickets

- https://getpocket.atlassian.net/browse/OSL-337
