### PR TITLE
OSL-339: Make slug optional on Snowplow ShareableList type

### DIFF
--- a/src/snowplow/events.spec.ts
+++ b/src/snowplow/events.spec.ts
@@ -88,6 +88,8 @@ describe('Snowplow event helpers', () => {
     expect(payload.shareableList.shareable_list_external_id).to.equal(
       shareableList.externalId
     );
+    // expect slug to be undefined
+    expect(payload.shareableList.slug).to.equal(undefined);
     // moderationStatus -> moderation_status
     expect(payload.shareableList.moderation_status).to.equal(
       shareableList.moderationStatus
@@ -132,6 +134,7 @@ describe('Snowplow event helpers', () => {
 
     // SHAREABLE_LIST_PUBLISHED
     // update some properties
+    shareableList.slug = 'updated-random-title';
     shareableList.status = ListStatus.PUBLIC;
     shareableList.updatedAt = new Date('2023-02-01 10:15:45');
     newUpdatedAt = shareableList.updatedAt;
@@ -145,6 +148,8 @@ describe('Snowplow event helpers', () => {
     expect(payload.eventType).to.equal(
       EventBridgeEventType.SHAREABLE_LIST_PUBLISHED
     );
+    // expect slug to not be null
+    expect(payload.shareableList.slug).to.equal(shareableList.slug);
     // check that status was updated to PUBLIC
     expect(payload.shareableList.status).to.equal(ListStatus.PUBLIC);
     // updatedAt -> updated_at in seconds

--- a/src/snowplow/events.ts
+++ b/src/snowplow/events.ts
@@ -24,7 +24,7 @@ function transformAPIShareableListToSnowplowShareableList(
 ): SnowplowShareableList {
   return {
     shareable_list_external_id: shareableList.externalId,
-    slug: shareableList.slug,
+    slug: shareableList.slug ? shareableList.slug : undefined,
     title: shareableList.title,
     description: shareableList.description
       ? shareableList.description
@@ -131,7 +131,6 @@ export async function sendEventHelper(
   options: EventBridgeEventOptions
 ) {
   let payload;
-
   if (options.shareableList) {
     payload = generateShareableListEventBridgePayload(
       eventType,

--- a/src/snowplow/types.ts
+++ b/src/snowplow/types.ts
@@ -36,7 +36,7 @@ export interface EventBridgeEventOptions {
  */
 export type SnowplowShareableList = {
   shareable_list_external_id: string;
-  slug: string;
+  slug?: string;
   title: string;
   description?: string;
   status: ListStatus;


### PR DESCRIPTION
## Goal

Analytics updated `slug` field to be optional on `shareable_list` entity. Updating `slug` field to be optional on Snowplow ShareableList type.

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-339](https://getpocket.atlassian.net/browse/OSL-339)