### PR TITLE
OSL-371: Enfore itemId to be required at Prisma level

### DIFF
--- a/prisma/migrations/20230404181758_adjust_item_id_field/migration.sql
+++ b/prisma/migrations/20230404181758_adjust_item_id_field/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `itemId` on table `ListItem` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE `ListItem` MODIFY `itemId` BIGINT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,8 +54,8 @@ model ListItem {
   externalId String   @default(uuid()) @db.VarChar(255)
   // The link to the parent List
   listId     BigInt
-  // Optional ID of Parser Item and Item props outside of this subgraph's control
-  itemId     BigInt?
+  // Required ID of Parser Item and Item props outside of this subgraph's control
+  itemId     BigInt
   url        String?  @db.VarChar(1000)
   title      String?  @db.VarChar(300)
   excerpt    String?  @db.Text

--- a/src/database/mutations/ShareableListItem.ts
+++ b/src/database/mutations/ShareableListItem.ts
@@ -61,13 +61,7 @@ export async function createShareableListItem(
 
   const input = {
     // coerce itemId to a number to conform to db schema
-    // if no itemId is set, send null. accepting null here should only
-    // occur in test scenarios, as we need to be able to mock list items that
-    // are missing itemId. as of this writing, the schema requires itemId.
-    // once we backfill old data missing itemId, we can revert this to:
-    // itemId: parseInt(data.itemId)
-    // https://getpocket.atlassian.net/browse/OSL-338
-    itemId: data.itemId ? parseInt(data.itemId) : null,
+    itemId: parseInt(data.itemId),
     url: data.url,
     title: data.title ?? undefined,
     excerpt: data.excerpt ?? undefined,

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -386,11 +386,8 @@ describe('public queries: ShareableList', () => {
         moderationStatus: ModerationStatus.VISIBLE,
       });
 
-      // Create a couple of list items, the first is missing an itemId (to
-      // mimic old data where itemId was not captured).
-      // once we backfill old data, we can remove the itemId: 0 below.
-      // https://getpocket.atlassian.net/browse/OSL-338
-      await createShareableListItemHelper(db, { list: newList, itemId: 0 });
+      // Create a couple of list items
+      await createShareableListItemHelper(db, { list: newList });
       await createShareableListItemHelper(db, { list: newList });
 
       // Run the query we're testing
@@ -421,6 +418,7 @@ describe('public queries: ShareableList', () => {
       // Let's run through the visible props of each item
       // to make sure they're all there
       result.body.data.shareableListPublic.listItems.forEach((listItem) => {
+        expect(listItem.itemId).not.to.be.empty;
         expect(listItem.url).not.to.be.empty;
         expect(listItem.title).not.to.be.empty;
         expect(listItem.excerpt).not.to.be.empty;

--- a/src/public/resolvers/utils.spec.ts
+++ b/src/public/resolvers/utils.spec.ts
@@ -10,18 +10,18 @@ import { sanitizeMutationInput, validateItemId } from './utils';
 
 describe('utility functions', () => {
   describe('validateItemId', () => {
-    it('does not throw an error for a missing itemId', () => {
+    it('does throw an error for a missing or empty itemId', () => {
       expect(() => {
         validateItemId(null);
-      }).not.to.throw();
+      }).to.throw(UserInputError);
 
       expect(() => {
         validateItemId(undefined);
-      }).not.to.throw();
+      }).to.throw(UserInputError);
 
       expect(() => {
-        validateItemId();
-      }).not.to.throw();
+        validateItemId('');
+      }).to.throw(UserInputError);
     });
 
     it('throws an error for a non-numeric itemId', () => {

--- a/src/public/resolvers/utils.ts
+++ b/src/public/resolvers/utils.ts
@@ -78,11 +78,11 @@ export async function validateUserId(
  * issues, yet needs to be stored as a number to match the canonical item
  * database table.
  *
- * @param itemId string | undefined
+ * @param itemId string
  * @returns void
  */
-export function validateItemId(itemId?: string) {
-  if (!itemId) return;
+export function validateItemId(itemId: string) {
+  if (!itemId) throw new UserInputError(`itemId is missing`);
 
   if (
     itemId &&

--- a/src/shared/resolvers/fields/PrismaBigInt.ts
+++ b/src/shared/resolvers/fields/PrismaBigInt.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 /**
- * Return a Number.
+ * Return a Number or Null (if not resolved).
  * Prisma returns a String when it retrieves the BigInt value stored in
  * the datastore (by appending a "n" char to the value).
  *
@@ -15,7 +15,7 @@ export const PrismaBigIntResolver = (parent, args, context, info) => {
   return parseFieldToInt(parent[info.fieldName]);
 };
 
-function parseFieldToInt(field: string) {
+export function parseFieldToInt(field: string): number | null {
   // as the schema now requires returning a value even when the db is missing the value
   // if !field, we should error to Sentry.
   if (!field) {

--- a/src/shared/resolvers/fields/PrismaBigInt.ts
+++ b/src/shared/resolvers/fields/PrismaBigInt.ts
@@ -16,11 +16,11 @@ export const PrismaBigIntResolver = (parent, args, context, info) => {
 };
 
 export function parseFieldToInt(field: string): number {
+  const parsedField = parseInt(field);
   // if for some reason the value is corrupt in the db, log to Sentry
-  if (!field || isNaN(parseInt(field))) {
+  if (!field || isNaN(parsedField)) {
     Sentry.captureException('Failed to parse itemId');
     return null;
   }
-  const parsedField = parseInt(field);
   return parsedField;
 }

--- a/src/shared/resolvers/fields/PrismaBigInt.ts
+++ b/src/shared/resolvers/fields/PrismaBigInt.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 /**
- * Return a Number or Null (if not resolved).
+ * Return a Number.
  * Prisma returns a String when it retrieves the BigInt value stored in
  * the datastore (by appending a "n" char to the value).
  *
@@ -15,13 +15,12 @@ export const PrismaBigIntResolver = (parent, args, context, info) => {
   return parseFieldToInt(parent[info.fieldName]);
 };
 
-export function parseFieldToInt(field: string): number | null {
-  // as the schema now requires returning a value even when the db is missing the value
-  // if !field, we should error to Sentry.
-  if (!field) {
-    Sentry.captureException('itemId cannot be null');
+export function parseFieldToInt(field: string): number {
+  // if for some reason the value is corrupt in the db, log to Sentry
+  if (!field || isNaN(parseInt(field))) {
+    Sentry.captureException('Failed to parse itemId');
     return null;
   }
   const parsedField = parseInt(field);
-  return isNaN(parsedField) ? null : parsedField;
+  return parsedField;
 }

--- a/src/shared/resolvers/fields/PrismaBigInt.ts
+++ b/src/shared/resolvers/fields/PrismaBigInt.ts
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/node';
+
 /**
  * Return a Number.
  * Prisma returns a String when it retrieves the BigInt value stored in
@@ -14,14 +16,12 @@ export const PrismaBigIntResolver = (parent, args, context, info) => {
 };
 
 function parseFieldToInt(field: string) {
-  // as the schema now requires returning a value even when the db is missing
-  // an itemId, we need to return an empty string (and not null)
-  // once we backfill, if !field, we should error to sentry.
-  // https://getpocket.atlassian.net/browse/OSL-338
+  // as the schema now requires returning a value even when the db is missing the value
+  // if !field, we should error to Sentry.
   if (!field) {
-    return '';
+    Sentry.captureException('itemId cannot be null');
+    return null;
   }
   const parsedField = parseInt(field);
-  // same here - if the parsed value is NaN, fall back to an empty string
-  return isNaN(parsedField) ? '' : parsedField;
+  return isNaN(parsedField) ? null : parsedField;
 }

--- a/src/shared/resolvers/fields/sharedResolversFields.spec.ts
+++ b/src/shared/resolvers/fields/sharedResolversFields.spec.ts
@@ -47,7 +47,8 @@ describe('Shared Resolver Helpers', () => {
       expect(sentryStub.getCall(0).firstArg).to.equal('Failed to parse itemId');
     });
     it('should successfully resolve value to int', async () => {
-      const itemId = '12345';
+      // db returns BigInts in 1234n format
+      const itemId = '12345n';
       const resolvedValue = parseFieldToInt(itemId);
       expect(resolvedValue).to.equal(12345);
       // Expect Sentry to NOT get invoked

--- a/src/shared/resolvers/fields/sharedResolversFields.spec.ts
+++ b/src/shared/resolvers/fields/sharedResolversFields.spec.ts
@@ -1,0 +1,33 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import * as Sentry from '@sentry/node';
+import { parseFieldToInt } from '../../../shared/resolvers/fields/PrismaBigInt';
+
+describe('Shared Resolver Helpers', () => {
+  let sentryStub;
+
+  beforeEach(() => {
+    sentryStub = sinon.stub(Sentry, 'captureException').resolves();
+  });
+
+  afterEach(() => {
+    sentryStub.restore();
+  });
+  describe('PrismaBigInt Resolver - parseFieldToInt function', () => {
+    it('should return null if field is string of chars', async () => {
+      const itemId = 'abc';
+      const resolvedValue = parseFieldToInt(itemId);
+      expect(resolvedValue).to.be.null;
+    });
+    it('should return null if field is null', async () => {
+      const itemId = null;
+      const resolvedValue = parseFieldToInt(itemId);
+      expect(resolvedValue).to.be.null;
+    });
+    it('should successfully resolve value to int', async () => {
+      const itemId = '12345';
+      const resolvedValue = parseFieldToInt(itemId);
+      expect(resolvedValue).to.equal(parseInt(itemId));
+    });
+  });
+});

--- a/src/shared/resolvers/fields/sharedResolversFields.spec.ts
+++ b/src/shared/resolvers/fields/sharedResolversFields.spec.ts
@@ -18,16 +18,40 @@ describe('Shared Resolver Helpers', () => {
       const itemId = 'abc';
       const resolvedValue = parseFieldToInt(itemId);
       expect(resolvedValue).to.be.null;
+      // Expect Sentry to get invoked and assert message
+      expect(sentryStub.callCount).to.equal(1);
+      expect(sentryStub.getCall(0).firstArg).to.equal('Failed to parse itemId');
     });
     it('should return null if field is null', async () => {
       const itemId = null;
       const resolvedValue = parseFieldToInt(itemId);
       expect(resolvedValue).to.be.null;
+      // Expect Sentry to get invoked and assert message
+      expect(sentryStub.callCount).to.equal(1);
+      expect(sentryStub.getCall(0).firstArg).to.equal('Failed to parse itemId');
+    });
+    it('should return null if field is undefined', async () => {
+      const itemId = undefined;
+      const resolvedValue = parseFieldToInt(itemId);
+      expect(resolvedValue).to.be.null;
+      // Expect Sentry to get invoked and assert message
+      expect(sentryStub.callCount).to.equal(1);
+      expect(sentryStub.getCall(0).firstArg).to.equal('Failed to parse itemId');
+    });
+    it('should return null if field is empty string', async () => {
+      const itemId = '';
+      const resolvedValue = parseFieldToInt(itemId);
+      expect(resolvedValue).to.be.null;
+      // Expect Sentry to get invoked and assert message
+      expect(sentryStub.callCount).to.equal(1);
+      expect(sentryStub.getCall(0).firstArg).to.equal('Failed to parse itemId');
     });
     it('should successfully resolve value to int', async () => {
       const itemId = '12345';
       const resolvedValue = parseFieldToInt(itemId);
-      expect(resolvedValue).to.equal(parseInt(itemId));
+      expect(resolvedValue).to.equal(12345);
+      // Expect Sentry to NOT get invoked
+      expect(sentryStub.callCount).to.equal(0);
     });
   });
 });

--- a/src/test/helpers/createShareableListItemHelper.ts
+++ b/src/test/helpers/createShareableListItemHelper.ts
@@ -27,12 +27,7 @@ export async function createShareableListItemHelper(
 ): Promise<ListItem> {
   const input = {
     listId: data.list.id,
-    // if 0 was explicitly sent, do NOT include an itemId. this is to mimic old
-    // data that's missing itemId in the db. once we've backfilled the old data
-    // we can revert this conditional to:
-    // itemId: data.itemId ?? faker.datatype.number()
-    // https://getpocket.atlassian.net/browse/OSL-338
-    itemId: data.itemId === 0 ? null : faker.datatype.number(),
+    itemId: data.itemId ?? faker.datatype.number(),
     url: data.url ?? `${faker.internet.url()}/${faker.lorem.slug(5)}`,
     title: data.title ?? faker.random.words(5),
     excerpt: data.excerpt ?? faker.lorem.sentences(2),


### PR DESCRIPTION
## Goal

`itemId` field has been backfilled now, so the field can be enforced to be required on the Prisma level. Cleaned up some code for passing a null `itemId`.

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-371](https://getpocket.atlassian.net/browse/OSL-371)
