### PR TITLE
OSL-388: Add userId to ShareableList Snowplow type

### DIFF
--- a/src/snowplow/events.spec.ts
+++ b/src/snowplow/events.spec.ts
@@ -89,6 +89,10 @@ describe('Snowplow event helpers', () => {
     expect(payload.shareableList.shareable_list_external_id).to.equal(
       shareableList.externalId
     );
+    // userId -> user_id
+    expect(payload.shareableList.user_id).to.equal(
+      parseInt(shareableList.userId as unknown as string)
+    );
     // expect slug to be undefined
     expect(payload.shareableList.slug).to.equal(undefined);
     // moderationStatus -> moderation_status
@@ -124,6 +128,10 @@ describe('Snowplow event helpers', () => {
     expect(payload.eventType).to.equal(
       EventBridgeEventType.SHAREABLE_LIST_UPDATED
     );
+    // userId -> user_id
+    expect(payload.shareableList.user_id).to.equal(
+      parseInt(shareableList.userId as unknown as string)
+    );
     // check that title was updated
     expect(payload.shareableList.title).to.equal('Updated random title');
     // check that description was updated
@@ -149,6 +157,10 @@ describe('Snowplow event helpers', () => {
     expect(payload.eventType).to.equal(
       EventBridgeEventType.SHAREABLE_LIST_PUBLISHED
     );
+    // userId -> user_id
+    expect(payload.shareableList.user_id).to.equal(
+      parseInt(shareableList.userId as unknown as string)
+    );
     // expect slug to not be null
     expect(payload.shareableList.slug).to.equal(shareableList.slug);
     // check that status was updated to PUBLIC
@@ -172,6 +184,10 @@ describe('Snowplow event helpers', () => {
     // check that the payload event type is for shareable-list-unpublished
     expect(payload.eventType).to.equal(
       EventBridgeEventType.SHAREABLE_LIST_UNPUBLISHED
+    );
+    // userId -> user_id
+    expect(payload.shareableList.user_id).to.equal(
+      parseInt(shareableList.userId as unknown as string)
     );
     // check that status was updated to PUBLIC
     expect(payload.shareableList.status).to.equal(ListStatus.PRIVATE);
@@ -209,6 +225,10 @@ describe('Snowplow event helpers', () => {
     // check that the payload event type is for shareable-list-hidden
     expect(payload.eventType).to.equal(
       EventBridgeEventType.SHAREABLE_LIST_HIDDEN
+    );
+    // userId -> user_id
+    expect(payload.shareableList.user_id).to.equal(
+      parseInt(shareableList.userId as unknown as string)
     );
     // check that moderation_status was updated to HIDDEN
     expect(payload.shareableList.moderation_status).to.equal(

--- a/src/snowplow/events.ts
+++ b/src/snowplow/events.ts
@@ -22,8 +22,14 @@ import {
 function transformAPIShareableListToSnowplowShareableList(
   shareableList: ShareableListComplete
 ): SnowplowShareableList {
+  // userId should always be present, but if for some reason it cannot be parsed,
+  // return undefined as userId is not required in Snowplow schema.
+  const userId = isNaN(parseInt(shareableList.userId as unknown as string))
+    ? undefined
+    : parseInt(shareableList.userId as unknown as string);
   return {
     shareable_list_external_id: shareableList.externalId,
+    user_id: userId,
     slug: shareableList.slug ? shareableList.slug : undefined,
     title: shareableList.title,
     description: shareableList.description
@@ -148,7 +154,6 @@ export async function sendEventHelper(
       options.listExternalId
     );
   }
-
   // Send payload to Event Bridge.
   try {
     await sendEvent(

--- a/src/snowplow/events.ts
+++ b/src/snowplow/events.ts
@@ -25,10 +25,7 @@ function transformAPIShareableListToSnowplowShareableList(
   // userId should always be present, but if for some reason it cannot be parsed,
   // return undefined as userId is not required in Snowplow schema. Log to Sentry.
   let userId;
-  if (
-    shareableList.userId &&
-    isNaN(parseInt(shareableList.userId as unknown as string))
-  ) {
+  if (isNaN(parseInt(shareableList.userId as unknown as string))) {
     userId = undefined;
     Sentry.captureException('Snowplow: Failed to parse userId');
   } else {

--- a/src/snowplow/events.ts
+++ b/src/snowplow/events.ts
@@ -23,10 +23,17 @@ function transformAPIShareableListToSnowplowShareableList(
   shareableList: ShareableListComplete
 ): SnowplowShareableList {
   // userId should always be present, but if for some reason it cannot be parsed,
-  // return undefined as userId is not required in Snowplow schema.
-  const userId = isNaN(parseInt(shareableList.userId as unknown as string))
-    ? undefined
-    : parseInt(shareableList.userId as unknown as string);
+  // return undefined as userId is not required in Snowplow schema. Log to Sentry.
+  let userId;
+  if (
+    shareableList.userId &&
+    isNaN(parseInt(shareableList.userId as unknown as string))
+  ) {
+    userId = undefined;
+    Sentry.captureException('Snowplow: Failed to parse userId');
+  } else {
+    userId = parseInt(shareableList.userId as unknown as string);
+  }
   return {
     shareable_list_external_id: shareableList.externalId,
     user_id: userId,

--- a/src/snowplow/types.ts
+++ b/src/snowplow/types.ts
@@ -36,6 +36,7 @@ export interface EventBridgeEventOptions {
  */
 export type SnowplowShareableList = {
   shareable_list_external_id: string;
+  user_id: bigint | number;
   slug?: string;
   title: string;
   description?: string;


### PR DESCRIPTION
## Goal

Sending `userId` as part of the ShareableList entity to Snowplow. As per [this request](https://pocket.slack.com/archives/CR6T8BNCT/p1680652916308989).

## Todos

- [x] test in dev

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-388](https://getpocket.atlassian.net/browse/OSL-388)
