### PR TITLE
feat(note visibility): add list item note visibility control to list

### DIFF
--- a/prisma/migrations/20230407161316_add_note_visibility_to_list/migration.sql
+++ b/prisma/migrations/20230407161316_add_note_visibility_to_list/migration.sql
@@ -1,0 +1,8 @@
+-- customized to require null after backfilling
+ALTER TABLE `List` ADD COLUMN `listItemNoteVisibility` ENUM('PRIVATE', 'PUBLIC') NULL DEFAULT 'PRIVATE';
+
+-- backfill all existing rows
+UPDATE `List` SET `listItemNoteVisibility` = 'PRIVATE';
+
+-- set field to NOT NULL
+ALTER TABLE `List` MODIFY `listItemNoteVisibility` ENUM('PRIVATE', 'PUBLIC') NOT NULL DEFAULT 'PRIVATE';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,7 +8,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-enum ListStatus {
+enum Visibility {
   PRIVATE
   PUBLIC
 }
@@ -21,21 +21,22 @@ enum ModerationStatus {
 model List {
   // *** Table fields ***
   // Prisma needs an integer ID to make relationships between tables
-  id                BigInt           @id @default(autoincrement())
+  id                      BigInt           @id @default(autoincrement())
   // This is our public-facing ID for use in Admin Tools and Snowplow event reporting
-  externalId        String           @default(uuid()) @db.VarChar(255)
+  externalId              String           @default(uuid()) @db.VarChar(255)
   // This is the Pocket ID. Sourced externally from a mutation input
-  userId            BigInt
-  slug              String?          @db.VarChar(300)
-  title             String           @db.VarChar(300)
-  description       String?          @db.Text
-  status            ListStatus       @default(PRIVATE)
-  moderationStatus  ModerationStatus @default(VISIBLE)
-  moderatedBy       String?          @db.VarChar(255)
-  moderationReason  String?          @db.Text
-  moderationDetails String?          @db.Text
-  createdAt         DateTime         @default(now()) @db.DateTime(0)
-  updatedAt         DateTime         @updatedAt
+  userId                  BigInt
+  slug                    String?          @db.VarChar(300)
+  title                   String           @db.VarChar(300)
+  description             String?          @db.Text
+  status                  Visibility       @default(PRIVATE)
+  moderationStatus        ModerationStatus @default(VISIBLE)
+  moderatedBy             String?          @db.VarChar(255)
+  moderationReason        String?          @db.Text
+  moderationDetails       String?          @db.Text
+  listItemNoteVisibility  Visibility       @default(PRIVATE)
+  createdAt               DateTime         @default(now()) @db.DateTime(0)
+  updatedAt               DateTime         @updatedAt
 
   // *** Associated models ***
   listItems ListItem[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { ListStatus, PilotUser, PrismaClient } from '@prisma/client';
+import { Visibility, PilotUser, PrismaClient } from '@prisma/client';
 import {
   createPilotUserHelper,
   createShareableListHelper,
@@ -44,7 +44,7 @@ async function main() {
     if (Math.random() > 0.5) {
       await updateShareableList(
         prisma,
-        { externalId: list.externalId, status: ListStatus.PUBLIC },
+        { externalId: list.externalId, status: Visibility.PUBLIC },
         randomUser.userId
       );
     }

--- a/src/admin/resolvers/queries/ShareableList.integration.ts
+++ b/src/admin/resolvers/queries/ShareableList.integration.ts
@@ -1,7 +1,7 @@
 import { ApolloServer } from '@apollo/server';
 import {
   List,
-  ListStatus,
+  Visibility,
   ModerationStatus,
   PrismaClient,
 } from '@prisma/client';
@@ -84,7 +84,7 @@ describe('admin queries: ShareableList', () => {
     it('should return a list with all props if it exists', async () => {
       // make list public
       await updateShareableListHelper(db, shareableList.externalId, {
-        status: ListStatus.PUBLIC,
+        status: Visibility.PUBLIC,
         slug: slugify(shareableList.title, config.slugify),
       });
 
@@ -113,7 +113,7 @@ describe('admin queries: ShareableList', () => {
       expect(list.description).to.equal(shareableList.description);
 
       // Default status values
-      expect(list.status).to.equal(ListStatus.PUBLIC);
+      expect(list.status).to.equal(Visibility.PUBLIC);
       expect(list.moderationStatus).to.equal(ModerationStatus.VISIBLE);
 
       // Variable values that just need to be non-null - we know Prisma

--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -1,5 +1,5 @@
 import { NotFoundError, UserInputError } from '@pocket-tools/apollo-utils';
-import { ListStatus, ModerationStatus, PrismaClient } from '@prisma/client';
+import { Visibility, ModerationStatus, PrismaClient } from '@prisma/client';
 import slugify from 'slugify';
 import {
   CreateShareableListInput,
@@ -145,7 +145,7 @@ export async function updateShareableList(
   // If there is no slug and the list is being shared with the world,
   // let's generate a unique slug from the title. Once set, it will not be
   // updated to sync with any further title edits.
-  if (data.status === ListStatus.PUBLIC && !list.slug) {
+  if (data.status === Visibility.PUBLIC && !list.slug) {
     // run the title through the slugify function
     const slugifiedTitle = slugify(data.title ?? list.title, config.slugify);
 
@@ -341,14 +341,14 @@ function updateShareableListBridgeEventHelper(
   // check if list status was updated
   if (data.status !== list.status) {
     // if list was published, send event bridge event for shareable-list-published event type
-    if (data.status === ListStatus.PUBLIC) {
+    if (data.status === Visibility.PUBLIC) {
       sendEventHelper(EventBridgeEventType.SHAREABLE_LIST_PUBLISHED, {
         shareableList: updatedList as ShareableListComplete,
         isShareableListEventType: true,
       });
     }
     // else if list was unpublished, send event bridge event for shareable-list-unpublished event type
-    else if (data.status === ListStatus.PRIVATE) {
+    else if (data.status === Visibility.PRIVATE) {
       sendEventHelper(EventBridgeEventType.SHAREABLE_LIST_UNPUBLISHED, {
         shareableList: updatedList as ShareableListComplete,
         isShareableListEventType: true,

--- a/src/database/queries/ShareableList.ts
+++ b/src/database/queries/ShareableList.ts
@@ -1,4 +1,4 @@
-import { ListStatus, ModerationStatus, PrismaClient } from '@prisma/client';
+import { Visibility, ModerationStatus, PrismaClient } from '@prisma/client';
 import { ShareableList, ShareableListComplete } from '../types';
 import { ForbiddenError, NotFoundError } from '@pocket-tools/apollo-utils';
 import { ACCESS_DENIED_ERROR } from '../../shared/constants';
@@ -50,7 +50,7 @@ export async function getShareableListPublic(
     where: {
       externalId,
       slug,
-      status: ListStatus.PUBLIC,
+      status: Visibility.PUBLIC,
     },
     include: {
       listItems: true,

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -1,4 +1,4 @@
-import { ListStatus, ModerationStatus, Prisma } from '@prisma/client';
+import { Visibility, ModerationStatus, Prisma } from '@prisma/client';
 
 /**
  * Source of truth: https://getpocket.atlassian.net/wiki/spaces/PE/pages/2584150049/Pocket+Shared+Data
@@ -106,7 +106,7 @@ export type UpdateShareableListInput = {
   externalId: string;
   title?: string;
   description?: string;
-  status?: ListStatus;
+  status?: Visibility;
   // Not in the public schema but here in the DB input type
   // because it's generated in the DB resolver if required.
   slug?: string;

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -5,7 +5,7 @@ import request from 'supertest';
 import { ApolloServer } from '@apollo/server';
 import {
   List,
-  ListStatus,
+  Visibility,
   ModerationStatus,
   PilotUser,
   PrismaClient,
@@ -159,7 +159,7 @@ describe('public mutations: ShareableList', () => {
       expect(list.title).to.equal(
         'My list to share&lt;script&gt;alert("Hello World!")&lt;/script&gt;'
       );
-      expect(list.status).to.equal(ListStatus.PRIVATE);
+      expect(list.status).to.equal(Visibility.PRIVATE);
       expect(list.moderationStatus).to.equal(ModerationStatus.VISIBLE);
 
       // user entity should match the creator's id
@@ -240,7 +240,7 @@ describe('public mutations: ShareableList', () => {
       expect(list.title).to.equal(
         'My list to share&lt;script&gt;alert("Hello World!")&lt;/script&gt;'
       );
-      expect(list.status).to.equal(ListStatus.PRIVATE);
+      expect(list.status).to.equal(Visibility.PRIVATE);
       expect(list.moderationStatus).to.equal(ModerationStatus.VISIBLE);
 
       // user entity should match the creator's id
@@ -341,7 +341,7 @@ describe('public mutations: ShareableList', () => {
       expect(result.body.data.createShareableList).to.exist;
       expect(result.body.data.createShareableList.title).to.equal(title1);
       expect(result.body.data.createShareableList.status).to.equal(
-        ListStatus.PRIVATE
+        Visibility.PRIVATE
       );
       expect(result.body.data.createShareableList.moderationStatus).to.equal(
         ModerationStatus.VISIBLE
@@ -369,7 +369,7 @@ describe('public mutations: ShareableList', () => {
       );
       expect(result.body.data.createShareableList.description).to.equal(null);
       expect(result.body.data.createShareableList.status).to.equal(
-        ListStatus.PRIVATE
+        Visibility.PRIVATE
       );
       expect(result.body.data.createShareableList.moderationStatus).to.equal(
         ModerationStatus.VISIBLE
@@ -527,7 +527,7 @@ describe('public mutations: ShareableList', () => {
         externalId: listToUpdate.externalId,
         title: 'This Will Be A Brand New Title',
         description: faker.lorem.sentences(2),
-        status: ListStatus.PRIVATE,
+        status: Visibility.PRIVATE,
       };
 
       const result = await request(app)
@@ -648,7 +648,7 @@ describe('public mutations: ShareableList', () => {
     it('should generate a slug if a list is being made public for the first time', async () => {
       const data: UpdateShareableListInput = {
         externalId: listToUpdate.externalId,
-        status: ListStatus.PUBLIC,
+        status: Visibility.PUBLIC,
       };
 
       const result = await request(app)
@@ -669,7 +669,7 @@ describe('public mutations: ShareableList', () => {
 
       // Verify that the updates have taken place
       const updatedList = result.body.data.updateShareableList;
-      expect(updatedList.status).to.equal(ListStatus.PUBLIC);
+      expect(updatedList.status).to.equal(Visibility.PUBLIC);
       expect(updatedList.slug).not.to.be.empty;
 
       // Does the slug match the current title?
@@ -682,7 +682,7 @@ describe('public mutations: ShareableList', () => {
       const data: UpdateShareableListInput = {
         externalId: listToUpdate.externalId,
         title: 'This Title is Different',
-        status: ListStatus.PUBLIC,
+        status: Visibility.PUBLIC,
       };
 
       const result = await request(app)
@@ -703,7 +703,7 @@ describe('public mutations: ShareableList', () => {
 
       // Verify that the updates have taken place
       const updatedList = result.body.data.updateShareableList;
-      expect(updatedList.status).to.equal(ListStatus.PUBLIC);
+      expect(updatedList.status).to.equal(Visibility.PUBLIC);
       expect(updatedList.slug).not.to.be.empty;
 
       // Does the slug match the updated title?
@@ -720,7 +720,7 @@ describe('public mutations: ShareableList', () => {
       // make list 1 PUBLIC
       dataList1 = {
         externalId: firstList.externalId,
-        status: ListStatus.PUBLIC,
+        status: Visibility.PUBLIC,
       };
 
       let result = await request(app)
@@ -741,7 +741,7 @@ describe('public mutations: ShareableList', () => {
 
       // Verify that the updates have taken place
       const updatedList = result.body.data.updateShareableList;
-      expect(updatedList.status).to.equal(ListStatus.PUBLIC);
+      expect(updatedList.status).to.equal(Visibility.PUBLIC);
       expect(updatedList.slug).not.to.be.empty;
 
       // Does the slug match the list 1 title?
@@ -773,7 +773,7 @@ describe('public mutations: ShareableList', () => {
 
       // Verify that the updates have taken place
       const updatedList1a = result.body.data.updateShareableList;
-      expect(updatedList1a.status).to.equal(ListStatus.PUBLIC);
+      expect(updatedList1a.status).to.equal(Visibility.PUBLIC);
       expect(updatedList1a.title).to.equal(dataList1.title);
       // We don't expect the slug to be updated. Tt should match the original generated slug (hangover-hotel).
       expect(updatedList1a.slug).to.equal(updatedList.slug);
@@ -786,7 +786,7 @@ describe('public mutations: ShareableList', () => {
       // make list 2 PUBLIC
       const dataList2 = {
         externalId: secondList.externalId,
-        status: ListStatus.PUBLIC,
+        status: Visibility.PUBLIC,
       };
 
       result = await request(app)
@@ -807,7 +807,7 @@ describe('public mutations: ShareableList', () => {
 
       // Verify that the updates have taken place
       const updatedList2 = result.body.data.updateShareableList;
-      expect(updatedList2.status).to.equal(ListStatus.PUBLIC);
+      expect(updatedList2.status).to.equal(Visibility.PUBLIC);
       expect(updatedList2.title).to.equal(secondList.title);
       // Expect the slug to equal hangover-hotel-2
       expect(updatedList2.slug).to.equal('hangover-hotel-2');
@@ -817,7 +817,7 @@ describe('public mutations: ShareableList', () => {
       const data: UpdateShareableListInput = {
         externalId: listToUpdate.externalId,
         title: 'This 👏 Title 👏 Is 👏 Full 👏 Of 👏 Emojis',
-        status: ListStatus.PUBLIC,
+        status: Visibility.PUBLIC,
       };
 
       const result = await request(app)
@@ -838,7 +838,7 @@ describe('public mutations: ShareableList', () => {
 
       // Verify that the updates have taken place
       const updatedList = result.body.data.updateShareableList;
-      expect(updatedList.status).to.equal(ListStatus.PUBLIC);
+      expect(updatedList.status).to.equal(Visibility.PUBLIC);
       expect(updatedList.slug).not.to.be.empty;
 
       // Does the slug look as expected?
@@ -849,7 +849,7 @@ describe('public mutations: ShareableList', () => {
       const data: UpdateShareableListInput = {
         externalId: listToUpdate.externalId,
         title: '👀 😱 😈 💚 👌 🔮️',
-        status: ListStatus.PUBLIC,
+        status: Visibility.PUBLIC,
       };
 
       const result = await request(app)
@@ -870,7 +870,7 @@ describe('public mutations: ShareableList', () => {
 
       // Verify that the updates have taken place
       const updatedList = result.body.data.updateShareableList;
-      expect(updatedList.status).to.equal(ListStatus.PUBLIC);
+      expect(updatedList.status).to.equal(Visibility.PUBLIC);
       expect(updatedList.slug).not.to.be.empty;
 
       // Since the slug is whittled away into nothingness with the removal
@@ -887,7 +887,7 @@ describe('public mutations: ShareableList', () => {
       // make list 1 PUBLIC
       const dataList1 = {
         externalId: firstList.externalId,
-        status: ListStatus.PUBLIC,
+        status: Visibility.PUBLIC,
       };
 
       let result = await request(app)
@@ -908,7 +908,7 @@ describe('public mutations: ShareableList', () => {
 
       // Verify that the updates have taken place
       const updatedList = result.body.data.updateShareableList;
-      expect(updatedList.status).to.equal(ListStatus.PUBLIC);
+      expect(updatedList.status).to.equal(Visibility.PUBLIC);
       expect(updatedList.slug).not.to.be.empty;
 
       // Is the slug the expected neutral name?
@@ -922,7 +922,7 @@ describe('public mutations: ShareableList', () => {
       // make list 2 PUBLIC
       const dataList2 = {
         externalId: secondList.externalId,
-        status: ListStatus.PUBLIC,
+        status: Visibility.PUBLIC,
       };
 
       result = await request(app)
@@ -943,7 +943,7 @@ describe('public mutations: ShareableList', () => {
 
       // Verify that the updates have taken place
       const updatedList2 = result.body.data.updateShareableList;
-      expect(updatedList2.status).to.equal(ListStatus.PUBLIC);
+      expect(updatedList2.status).to.equal(Visibility.PUBLIC);
       expect(updatedList2.title).to.equal(secondList.title);
       // Expect the slug to equal shared-list-2
       expect(updatedList2.slug).to.equal('shared-list-2');
@@ -958,7 +958,7 @@ describe('public mutations: ShareableList', () => {
       // make list 1 PUBLIC
       const dataList1 = {
         externalId: firstList.externalId,
-        status: ListStatus.PUBLIC,
+        status: Visibility.PUBLIC,
       };
 
       let result = await request(app)
@@ -978,7 +978,7 @@ describe('public mutations: ShareableList', () => {
 
       // Verify that the updates have taken place
       const updatedList = result.body.data.updateShareableList;
-      expect(updatedList.status).to.equal(ListStatus.PUBLIC);
+      expect(updatedList.status).to.equal(Visibility.PUBLIC);
       expect(updatedList.slug).not.to.be.empty;
 
       // Does the slug match the list 1 title (hangover-hotel)?
@@ -996,7 +996,7 @@ describe('public mutations: ShareableList', () => {
       // make list 2 PUBLIC
       const dataList2 = {
         externalId: secondList.externalId,
-        status: ListStatus.PUBLIC,
+        status: Visibility.PUBLIC,
       };
 
       result = await request(app)
@@ -1016,7 +1016,7 @@ describe('public mutations: ShareableList', () => {
 
       // Verify that the updates have taken place
       const updatedList2 = result.body.data.updateShareableList;
-      expect(updatedList2.status).to.equal(ListStatus.PUBLIC);
+      expect(updatedList2.status).to.equal(Visibility.PUBLIC);
       expect(updatedList2.title).to.equal(secondList.title);
       // Expect the slug to equal hangover-hotel
       expect(updatedList2.slug).to.equal(
@@ -1029,7 +1029,7 @@ describe('public mutations: ShareableList', () => {
       const data: UpdateShareableListInput = {
         externalId: listToUpdate.externalId,
         title: 'This Title Could Not Be More Different',
-        status: ListStatus.PUBLIC,
+        status: Visibility.PUBLIC,
       };
 
       const result = await request(app)
@@ -1056,7 +1056,7 @@ describe('public mutations: ShareableList', () => {
         externalId: listToUpdate.externalId,
         title: 'Suddenly This List is Private Again',
         description: 'I really should have kept this to myself',
-        status: ListStatus.PRIVATE,
+        status: Visibility.PRIVATE,
       };
 
       const result2 = await request(app)
@@ -1076,7 +1076,7 @@ describe('public mutations: ShareableList', () => {
 
       // Verify that the updates have taken place
       const updatedList = result2.body.data.updateShareableList;
-      expect(updatedList.status).to.equal(ListStatus.PRIVATE);
+      expect(updatedList.status).to.equal(Visibility.PRIVATE);
       expect(updatedList.title).to.equal(data2.title);
       expect(updatedList.description).to.equal(data2.description);
 

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -5,7 +5,7 @@ import request from 'supertest';
 import { ApolloServer } from '@apollo/server';
 import {
   List,
-  ListStatus,
+  Visibility,
   ModerationStatus,
   PilotUser,
   PrismaClient,
@@ -150,7 +150,7 @@ describe('public queries: ShareableList', () => {
       expect(list.description).to.equal(shareableList.description);
 
       // Default status values
-      expect(list.status).to.equal(ListStatus.PRIVATE);
+      expect(list.status).to.equal(Visibility.PRIVATE);
       expect(list.moderationStatus).to.equal(ModerationStatus.VISIBLE);
 
       // Variable values that just need to be non-null - we know Prisma
@@ -239,7 +239,7 @@ describe('public queries: ShareableList', () => {
         userId: parseInt(headers.userId),
         title: 'This is a list that does not comply with our policies',
         slug: 'this-is-a-list-that-does-not-comply',
-        status: ListStatus.PUBLIC,
+        status: Visibility.PUBLIC,
         moderationStatus: ModerationStatus.HIDDEN,
       });
 
@@ -267,7 +267,7 @@ describe('public queries: ShareableList', () => {
         userId: parseInt(headers.userId),
         title: 'This is a list that is Private',
         slug: 'this-is-a-list-that-is-private',
-        status: ListStatus.PRIVATE,
+        status: Visibility.PRIVATE,
         moderationStatus: ModerationStatus.VISIBLE,
       });
 
@@ -297,7 +297,7 @@ describe('public queries: ShareableList', () => {
         userId: parseInt(headers.userId),
         title: 'This is a list',
         slug: 'this-is-a-list',
-        status: ListStatus.PUBLIC,
+        status: Visibility.PUBLIC,
         moderationStatus: ModerationStatus.VISIBLE,
       });
 
@@ -327,7 +327,7 @@ describe('public queries: ShareableList', () => {
         userId: parseInt(headers.userId),
         title: 'This is a list that does comply with our policies',
         slug: 'this-is-a-list-that-does-comply',
-        status: ListStatus.PUBLIC,
+        status: Visibility.PUBLIC,
         moderationStatus: ModerationStatus.VISIBLE,
       });
 
@@ -358,7 +358,7 @@ describe('public queries: ShareableList', () => {
       expect(list.description).to.equal(newList.description);
 
       // Default status values
-      expect(list.status).to.equal(ListStatus.PUBLIC);
+      expect(list.status).to.equal(Visibility.PUBLIC);
       expect(list.moderationStatus).to.equal(ModerationStatus.VISIBLE);
 
       // Variable values that just need to be non-null - we know Prisma
@@ -382,7 +382,7 @@ describe('public queries: ShareableList', () => {
         userId: parseInt(headers.userId),
         title: 'This is a new list',
         slug: 'the-slug',
-        status: ListStatus.PUBLIC,
+        status: Visibility.PUBLIC,
         moderationStatus: ModerationStatus.VISIBLE,
       });
 
@@ -502,7 +502,7 @@ describe('public queries: ShareableList', () => {
           listArray[i].description
         );
         expect(result.body.data.shareableLists[i].status).to.equal(
-          ListStatus.PRIVATE
+          Visibility.PRIVATE
         );
         expect(result.body.data.shareableLists[i].moderationStatus).to.equal(
           ModerationStatus.VISIBLE

--- a/src/snowplow/events.spec.ts
+++ b/src/snowplow/events.spec.ts
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 import * as Sentry from '@sentry/node';
 import { EventBridgeClient } from '@aws-sdk/client-eventbridge';
-import { ListStatus, ModerationStatus } from '@prisma/client';
+import { Visibility, ModerationStatus } from '@prisma/client';
 import {
   ShareableListModerationReason,
   ShareableListComplete,
@@ -29,7 +29,7 @@ describe('Snowplow event helpers', () => {
     slug: null,
     title: 'Fake Random Title',
     description: faker.lorem.sentences(2),
-    status: ListStatus.PRIVATE,
+    status: Visibility.PRIVATE,
     moderationStatus: ModerationStatus.VISIBLE,
     moderatedBy: null,
     moderationReason: null,
@@ -144,7 +144,7 @@ describe('Snowplow event helpers', () => {
     // SHAREABLE_LIST_PUBLISHED
     // update some properties
     shareableList.slug = 'updated-random-title';
-    shareableList.status = ListStatus.PUBLIC;
+    shareableList.status = Visibility.PUBLIC;
     shareableList.updatedAt = new Date('2023-02-01 10:15:45');
     newUpdatedAt = shareableList.updatedAt;
     payload = await generateShareableListEventBridgePayload(
@@ -164,7 +164,7 @@ describe('Snowplow event helpers', () => {
     // expect slug to not be null
     expect(payload.shareableList.slug).to.equal(shareableList.slug);
     // check that status was updated to PUBLIC
-    expect(payload.shareableList.status).to.equal(ListStatus.PUBLIC);
+    expect(payload.shareableList.status).to.equal(Visibility.PUBLIC);
     // updatedAt -> updated_at in seconds
     expect(payload.shareableList.updated_at).to.equal(
       Math.floor(newUpdatedAt.getTime() / 1000)
@@ -172,7 +172,7 @@ describe('Snowplow event helpers', () => {
 
     // SHAREABLE_LIST_UNPUBLISHED
     // update some properties
-    shareableList.status = ListStatus.PRIVATE;
+    shareableList.status = Visibility.PRIVATE;
     shareableList.updatedAt = new Date('2023-02-02 10:15:07');
     newUpdatedAt = shareableList.updatedAt;
     payload = await generateShareableListEventBridgePayload(
@@ -190,7 +190,7 @@ describe('Snowplow event helpers', () => {
       parseInt(shareableList.userId as unknown as string)
     );
     // check that status was updated to PUBLIC
-    expect(payload.shareableList.status).to.equal(ListStatus.PRIVATE);
+    expect(payload.shareableList.status).to.equal(Visibility.PRIVATE);
     // updatedAt -> updated_at in seconds
     expect(payload.shareableList.updated_at).to.equal(
       Math.floor(newUpdatedAt.getTime() / 1000)

--- a/src/snowplow/types.ts
+++ b/src/snowplow/types.ts
@@ -1,4 +1,4 @@
-import { ListStatus, ModerationStatus } from '@prisma/client';
+import { Visibility, ModerationStatus } from '@prisma/client';
 import { ShareableListComplete, ShareableListItem } from '../database/types';
 
 export type ShareableListEventBusPayload = {
@@ -40,7 +40,7 @@ export type SnowplowShareableList = {
   slug?: string;
   title: string;
   description?: string;
-  status: ListStatus;
+  status: Visibility;
   moderation_status: ModerationStatus;
   moderated_by?: string;
   moderation_reason?: string;

--- a/src/test/helpers/createShareableListHelper.ts
+++ b/src/test/helpers/createShareableListHelper.ts
@@ -1,6 +1,6 @@
 import {
   List,
-  ListStatus,
+  Visibility,
   ModerationStatus,
   PrismaClient,
 } from '@prisma/client';
@@ -11,7 +11,7 @@ interface ListHelperInput {
   title: string;
   description?: string;
   slug?: string;
-  status?: ListStatus;
+  status?: Visibility;
   moderationStatus?: ModerationStatus;
 }
 

--- a/src/test/helpers/updateShareableListHelper.ts
+++ b/src/test/helpers/updateShareableListHelper.ts
@@ -1,7 +1,7 @@
-import { List, ListStatus, PrismaClient } from '@prisma/client';
+import { List, Visibility, PrismaClient } from '@prisma/client';
 
 interface UpdateListHelperInput {
-  status: ListStatus;
+  status: Visibility;
   slug: string;
 }
 


### PR DESCRIPTION
## Goal

add list item note visibility control to list entity.

- backfills existing rows to have PRIVATE visibility

[successfully deployed to dev](https://app.circleci.com/pipelines/github/Pocket/shareable-lists-api/942/workflows/9e331cff-bd17-4b32-be3f-38d019d28d03) (also manually verified db integrity/data).

## Deployment

- [ ] deployed to dev?

## Tickets

- https://getpocket.atlassian.net/browse/OSL-394

## Implementation Decisions

renamed the prisma enum `ListStatus` to the more general `Visibility` for semantic re-use here.
