### PR TITLE
feat(listItemNoteVisibility): add field to the API

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -46,7 +46,7 @@ type ShareableListComplete implements ShareableListInterface {
   """
   The status of the list. Defaults to PRIVATE.
   """
-  status: ShareableListStatus!
+  status: ShareableListVisibility!
   """
   The moderation status of the list. Defaults to VISIBLE.
   """
@@ -64,6 +64,10 @@ type ShareableListComplete implements ShareableListInterface {
   Pocket Saves that have been added to this list by the Pocket user.
   """
   listItems: [ShareableListItem!]!
+  """
+  The visibility of notes added to list items for this list.
+  """
+  listItemNoteVisibility: ShareableListVisibility!
   """
   The LDAP username of the moderator who took down a list
   that violates the Pocket content moderation policy.

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -26,7 +26,7 @@ type ShareableList implements ShareableListInterface {
   """
   The status of the list. Defaults to PRIVATE.
   """
-  status: ShareableListStatus!
+  status: ShareableListVisibility!
   """
   The moderation status of the list. Defaults to VISIBLE.
   """
@@ -44,6 +44,10 @@ type ShareableList implements ShareableListInterface {
   Pocket Saves that have been added to this list by the Pocket user.
   """
   listItems: [ShareableListItem!]!
+  """
+  The visibility of notes added to list items for this list.
+  """
+  listItemNoteVisibility: ShareableListVisibility!
 }
 
 """
@@ -76,7 +80,7 @@ type ShareableListPublic implements ShareableListInterface
   """
   The status of the list. Defaults to PRIVATE.
   """
-  status: ShareableListStatus!
+  status: ShareableListVisibility!
   """
   The moderation status of the list. Defaults to VISIBLE.
   """
@@ -102,6 +106,7 @@ Input data for creating a Shareable List.
 input CreateShareableListInput {
   title: String!
   description: String
+  listItemNoteVisibility: ShareableListVisibility
 }
 
 """
@@ -111,7 +116,8 @@ input UpdateShareableListInput {
   externalId: ID!
   title: String
   description: String
-  status: ShareableListStatus
+  status: ShareableListVisibility
+  listItemNoteVisibility: ShareableListVisibility
 }
 
 """

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -17,15 +17,15 @@ A URL to a web page or image.
 scalar Url
 
 """
-The status of a Shareable List. Defaults to PRIVATE - visible only to its owner.
+The visibility levels used (e.g. list, list item note) in the Shareable List API. Defaults to PRIVATE - visible only to its owner.
 """
-enum ShareableListStatus {
+enum ShareableListVisibility {
   """
-  The list is only visible to its owner - the Pocket user who created it.
+  Only visible to its owner - the Pocket user who created it.
   """
   PRIVATE
   """
-  The list has been shared and can be viewed by anyone in the world.
+  Can be viewed by anyone in the world.
   """
   PUBLIC
 }
@@ -130,7 +130,7 @@ interface ShareableListInterface {
   """
   The status of the list. Defaults to PRIVATE.
   """
-  status: ShareableListStatus!
+  status: ShareableListVisibility!
   """
   The moderation status of the list. Defaults to VISIBLE.
   """

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -73,6 +73,7 @@ const shareableListSelectFields = {
   createdAt: true,
   updatedAt: true,
   listItems: { select: shareableListItemSelectFields },
+  listItemNoteVisibility: true,
 };
 const shareableList = Prisma.validator<Prisma.ListArgs>()({
   select: shareableListSelectFields,
@@ -100,6 +101,7 @@ export type CreateShareableListInput = {
   title: string;
   description?: string;
   listItem?: CreateShareableListItemInput;
+  listItemNoteVisibility?: Visibility;
 };
 
 export type UpdateShareableListInput = {
@@ -107,6 +109,7 @@ export type UpdateShareableListInput = {
   title?: string;
   description?: string;
   status?: Visibility;
+  listItemNoteVisibility?: Visibility;
   // Not in the public schema but here in the DB input type
   // because it's generated in the DB resolver if required.
   slug?: string;

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -78,6 +78,8 @@ describe('public queries: ShareableList', () => {
     shareableList2 = await createShareableListHelper(db, {
       userId: parseInt(headers.userId),
       title: 'This is a second test list',
+      // set list item notes public
+      listItemNoteVisibility: Visibility.PUBLIC,
     });
   });
 
@@ -167,6 +169,9 @@ describe('public queries: ShareableList', () => {
 
       // Empty list items array
       expect(list.listItems).to.have.lengthOf(0);
+
+      // default list item note visibility (not set explicitly upon creation)
+      expect(list.listItemNoteVisibility).to.equal(Visibility.PRIVATE);
     });
 
     it('should return a list with list items', async () => {
@@ -488,31 +493,28 @@ describe('public queries: ShareableList', () => {
 
       // Expect the array length to contain 2 lists
       expect(result.body.data.shareableLists.length).to.equal(2);
+
       // We also want to assert that the first list returned in the array is the most recently created
       const listArray = [shareableList2, shareableList];
+
+      let list;
+
       // Loop over both lists and check their values are as expected
       for (let i = 0; i < listArray.length; i++) {
-        expect(result.body.data.shareableLists[i].title).to.equal(
-          listArray[i].title
-        );
-        expect(result.body.data.shareableLists[i].slug).to.equal(
-          listArray[i].slug
-        );
-        expect(result.body.data.shareableLists[i].description).to.equal(
-          listArray[i].description
-        );
-        expect(result.body.data.shareableLists[i].status).to.equal(
-          Visibility.PRIVATE
-        );
-        expect(result.body.data.shareableLists[i].moderationStatus).to.equal(
-          ModerationStatus.VISIBLE
-        );
-        expect(result.body.data.shareableLists[i].createdAt).not.to.be.empty;
-        expect(result.body.data.shareableLists[i].updatedAt).not.to.be.empty;
-        expect(result.body.data.shareableLists[i].externalId).not.to.be.empty;
+        list = result.body.data.shareableLists[i];
+
+        expect(list.title).to.equal(listArray[i].title);
+        expect(list.slug).to.equal(listArray[i].slug);
+        expect(list.description).to.equal(listArray[i].description);
+        expect(list.status).to.equal(Visibility.PRIVATE);
+        expect(list.moderationStatus).to.equal(ModerationStatus.VISIBLE);
+        expect(list.createdAt).not.to.be.empty;
+        expect(list.updatedAt).not.to.be.empty;
+        expect(list.externalId).not.to.be.empty;
         // Empty list items array
-        expect(result.body.data.shareableLists[i].listItems).to.have.lengthOf(
-          0
+        expect(list.listItems).to.have.lengthOf(0);
+        expect(list.listItemNoteVisibility).to.equal(
+          listArray[i].listItemNoteVisibility
         );
       }
     });

--- a/src/shared/fragments.gql.ts
+++ b/src/shared/fragments.gql.ts
@@ -40,6 +40,7 @@ export const ShareableListPublicProps = gql`
     listItems {
       ...ShareableListItemPublicProps
     }
+    listItemNoteVisibility
   }
   ${ShareableListItemPublicProps}
 `;

--- a/src/snowplow/events.spec.ts
+++ b/src/snowplow/events.spec.ts
@@ -37,6 +37,7 @@ describe('Snowplow event helpers', () => {
     createdAt: new Date('2023-01-01 10:10:10'),
     updatedAt: new Date('2023-01-01 10:10:10'),
     listItems: [],
+    listItemNoteVisibility: Visibility.PRIVATE,
   };
 
   const shareableListItem: ShareableListItem = {

--- a/src/test/helpers/createShareableListHelper.ts
+++ b/src/test/helpers/createShareableListHelper.ts
@@ -13,6 +13,7 @@ interface ListHelperInput {
   slug?: string;
   status?: Visibility;
   moderationStatus?: ModerationStatus;
+  listItemNoteVisibility?: Visibility;
 }
 
 /**
@@ -34,6 +35,7 @@ export async function createShareableListHelper(
     slug: data.slug ?? undefined,
     status: data.status ?? undefined,
     moderationStatus: data.moderationStatus ?? ModerationStatus.VISIBLE,
+    listItemNoteVisibility: data.listItemNoteVisibility ?? undefined,
   };
 
   return await prisma.list.create({


### PR DESCRIPTION
## Goal

add `listItemNoteVisibility` field to the API

- small refactor of some tests
- renamed `ShareableListStauts` graph enum to `ShareableListVisibility`

verified with web team that the enum rename is safe on their end (they only use the values, which aren't changing).

## Tickets

- https://getpocket.atlassian.net/browse/OSL-395

