### PR TITLE
feat(list item note): add note to list item db model

### DIFF
--- a/prisma/migrations/20230412145457_add_note_to_list_items/migration.sql
+++ b/prisma/migrations/20230412145457_add_note_to_list_items/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `ListItem` ADD COLUMN `note` VARCHAR(1000) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,6 +60,8 @@ model ListItem {
   url        String?  @db.VarChar(1000)
   title      String?  @db.VarChar(300)
   excerpt    String?  @db.Text
+  // Optional user-supplied note to accompany the item. Length of 300 enforced at graph level
+  note       String?  @db.VarChar(1000)
   imageUrl   String?  @db.VarChar(1000)
   publisher  String?  @db.VarChar(300)
   authors    String?  @db.VarChar(1000)


### PR DESCRIPTION
## Goal

adds a `note` field to the `ListItem` model to store user-supplied notes to items in their lists.

## Tickets

- [OSL-391](https://getpocket.atlassian.net/browse/OSL-391)

## Implementation Decisions

we are limiting the length to 300 characters initially, but i made the db field larger for potential expansion in the future. we've done this for other fields in this repo - should we continue this practice? 
