### PR TITLE
OSL-386: Execute data deletion from /deleteUserData express endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "graphql-tag": "2.12.6",
         "graphql-upload": "15.0.2",
         "keyv": "^4.5.2",
-        "nanoid": "^3.3.4",
         "sinon": "^15.0.1",
         "slugify": "1.6.6",
         "uuid": "9.0.0",
@@ -6563,17 +6562,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "graphql-tag": "2.12.6",
     "graphql-upload": "15.0.2",
     "keyv": "^4.5.2",
-    "nanoid": "^3.3.4",
     "sinon": "^15.0.1",
     "slugify": "1.6.6",
     "uuid": "9.0.0",

--- a/src/public/routes/deleteUserData.integration.ts
+++ b/src/public/routes/deleteUserData.integration.ts
@@ -14,6 +14,10 @@ import {
   createShareableListItemHelper,
   mockRedisServer,
 } from '../../test/helpers';
+import {
+  getAllShareableListIdsForUser,
+  deleteShareableListItemsForUser,
+} from './deleteUserData';
 
 describe('/deleteUserData express endpoint', () => {
   let app: Express.Application;
@@ -21,7 +25,11 @@ describe('/deleteUserData express endpoint', () => {
   let graphQLUrl: string;
   let db: PrismaClient;
   let sentryStub;
+  let list1;
+  let list2;
+  let list3;
 
+  let pilotUser2;
   const headers = {
     userId: '8009882300',
   };
@@ -54,33 +62,40 @@ describe('/deleteUserData express endpoint', () => {
     await createPilotUserHelper(db, {
       userId: parseInt(headers.userId),
     });
+
+    pilotUser2 = await createPilotUserHelper(db, {
+      userId: 76543,
+    });
+
+    // Create a few Lists
+    list1 = await createShareableListHelper(db, {
+      userId: parseInt(headers.userId),
+      title: 'Simon Le Bon List',
+    });
+
+    list2 = await createShareableListHelper(db, {
+      userId: parseInt(headers.userId),
+      title: 'Bon Voyage List',
+    });
+
+    // Create a List for user 2
+    list3 = await createShareableListHelper(db, {
+      userId: pilotUser2.userId,
+      title: 'Rolling Stones List',
+    });
+
+    // then create 5 list items for each list
+    for (let i = 0; i < 5; i++) {
+      await createShareableListItemHelper(db, {
+        list: list1,
+      });
+      await createShareableListItemHelper(db, {
+        list: list2,
+      });
+    }
   });
 
   describe('should delete all shareable list user data for userId', () => {
-    beforeEach(async () => {
-      // Create a few Lists
-      const list1 = await createShareableListHelper(db, {
-        userId: parseInt(headers.userId),
-        title: 'Simon Le Bon List',
-      });
-
-      const list2 = await createShareableListHelper(db, {
-        userId: parseInt(headers.userId),
-        title: 'Bon Voyage List',
-      });
-
-      // then create some random # of list items for each list
-      const makeItems = Math.floor(Math.random() * 4) + 1;
-      for (let i = 0; i < makeItems; i++) {
-        await createShareableListItemHelper(db, {
-          list: list1,
-        });
-        await createShareableListItemHelper(db, {
-          list: list2,
-        });
-      }
-    });
-
     it('should not delete any data for userId with no data and should not return error', async () => {
       const result = await request(app)
         .post(graphQLUrl + 'deleteUserData')
@@ -110,6 +125,49 @@ describe('/deleteUserData express endpoint', () => {
       expect(result.body.message).to.contain(
         `Deleting shareable lists data for User ID: ${headers.userId}`
       );
+      // lets manually call getAllShareableListIdsForUser to check there are no lists for this user
+      const ids = await getAllShareableListIdsForUser(parseInt(headers.userId));
+      expect(ids.length).to.equal(0);
+    });
+  });
+
+  describe('getAllShareableListIdsForUser', () => {
+    it('should return empty array for userId with no lists in db', async () => {
+      const ids = await getAllShareableListIdsForUser(234567);
+      expect(ids.length).to.equal(0);
+    });
+    it('should return appropriate list ids for user', async () => {
+      let ids = await getAllShareableListIdsForUser(parseInt(headers.userId));
+      expect(ids.length).to.equal(2);
+      // check the returned ids are what we expect
+      expect(ids[0]).to.equal(parseInt(list1.id as unknown as string));
+      expect(ids[1]).to.equal(parseInt(list2.id as unknown as string));
+
+      // get listIds for another user
+      ids = await getAllShareableListIdsForUser(pilotUser2.userId);
+      expect(ids.length).to.equal(1);
+      // check the returned ids are what we expect
+      expect(ids[0]).to.equal(parseInt(list3.id as unknown as string));
+    });
+  });
+
+  describe('deleteShareableListItemsForUser', () => {
+    it('should return count=0 for deleting 0 list items for user with no list items', async () => {
+      // pilotUser 2 has one list (list3) but 0 list items
+      const count = await deleteShareableListItemsForUser([
+        parseInt(list3.id as unknown as string),
+      ]);
+      // there should be no list items found for list 3
+      expect(count).to.equal(0);
+    });
+    it('should return correct count of deleted list items for user with list items', async () => {
+      // pilotUser 1 has two lists (list1, list2) and 5 list items per list
+      const count = await deleteShareableListItemsForUser([
+        parseInt(list1.id as unknown as string),
+        parseInt(list2.id as unknown as string),
+      ]);
+      // there should be 10 total list items deleted
+      expect(count).to.equal(10);
     });
   });
 });

--- a/src/public/routes/deleteUserData.integration.ts
+++ b/src/public/routes/deleteUserData.integration.ts
@@ -1,0 +1,115 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import request from 'supertest';
+import { ApolloServer } from '@apollo/server';
+import * as Sentry from '@sentry/node';
+import { PrismaClient } from '@prisma/client';
+import { startServer } from '../../express';
+import { IPublicContext } from '../context';
+import { client } from '../../database/client';
+import {
+  clearDb,
+  createPilotUserHelper,
+  createShareableListHelper,
+  createShareableListItemHelper,
+  mockRedisServer,
+} from '../../test/helpers';
+
+describe('/deleteUserData express endpoint', () => {
+  let app: Express.Application;
+  let server: ApolloServer<IPublicContext>;
+  let graphQLUrl: string;
+  let db: PrismaClient;
+  let sentryStub;
+
+  const headers = {
+    userId: '8009882300',
+  };
+
+  beforeAll(async () => {
+    mockRedisServer();
+    // port 0 tells express to dynamically assign an available port
+    ({
+      app,
+      publicServer: server,
+      publicUrl: graphQLUrl,
+    } = await startServer(0));
+    db = client();
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+    await server.stop();
+  });
+
+  afterEach(() => {
+    sentryStub.restore();
+  });
+
+  beforeEach(async () => {
+    sentryStub = sinon.stub(Sentry, 'captureException').resolves();
+    await clearDb(db);
+
+    // create pilot users
+    await createPilotUserHelper(db, {
+      userId: parseInt(headers.userId),
+    });
+  });
+
+  describe('should delete all shareable list user data for userId', () => {
+    beforeEach(async () => {
+      // Create a few Lists
+      const list1 = await createShareableListHelper(db, {
+        userId: parseInt(headers.userId),
+        title: 'Simon Le Bon List',
+      });
+
+      const list2 = await createShareableListHelper(db, {
+        userId: parseInt(headers.userId),
+        title: 'Bon Voyage List',
+      });
+
+      // then create some random # of list items for each list
+      const makeItems = Math.floor(Math.random() * 4) + 1;
+      for (let i = 0; i < makeItems; i++) {
+        await createShareableListItemHelper(db, {
+          list: list1,
+        });
+        await createShareableListItemHelper(db, {
+          list: list2,
+        });
+      }
+    });
+
+    it('should not delete any data for userId with no data and should not return error', async () => {
+      const result = await request(app)
+        .post(graphQLUrl + 'deleteUserData')
+        .set('Content-Type', 'application/json')
+        .send({ userId: '12345' });
+      expect(result.body.status).to.equal('OK');
+      expect(result.body.message).to.contain(
+        `No shareable list data to delete for User ID: 12345`
+      );
+    });
+
+    it('should fail deleteUserData schema validation if bad userId', async () => {
+      const result = await request(app)
+        .post(graphQLUrl + 'deleteUserData')
+        .set('Content-Type', 'application/json')
+        .send({ userId: 'abc-12345' });
+      expect(result.body.errors.length).to.equal(1);
+      expect(result.body.errors[0].msg).to.equal('Must provide valid userId');
+    });
+
+    it('should successfully deleteUserData for a userId', async () => {
+      const result = await request(app)
+        .post(graphQLUrl + 'deleteUserData')
+        .set('Content-Type', 'application/json')
+        .send({ userId: headers.userId });
+      expect(result.body.status).to.equal('OK');
+      expect(result.body.message).to.contain(
+        `Deleting shareable lists data for User ID: ${headers.userId}`
+      );
+    });
+  });
+});

--- a/src/public/routes/deleteUserData.ts
+++ b/src/public/routes/deleteUserData.ts
@@ -44,20 +44,18 @@ function validate(req: Request, res: Response, next: NextFunction) {
  * This method returns an array of shareable list ids for a user
  * @param userId
  */
-async function getAllShareableListIdsForUser(
+export async function getAllShareableListIdsForUser(
   userId: number | bigint
 ): Promise<number[] | bigint[]> {
   const shareableLists = await db.list.findMany({
     where: {
       userId,
     },
-    orderBy: { updatedAt: 'desc' },
-    include: {
-      listItems: true,
-    },
   });
   const shareableListIds = [];
   shareableLists.forEach(function (list) {
+    // db spits list.id as 1n (bigint) but needs to be interpreted as string in order
+    // to apply parseInt which accepts a str argument, hence, double casting
     shareableListIds.push(parseInt(list.id as unknown as string));
   });
   return shareableListIds;
@@ -67,7 +65,7 @@ async function getAllShareableListIdsForUser(
  * This method deletes shareable list items in bulk for a user
  * @param listIds
  */
-async function deleteShareableListItemsForUser(
+export async function deleteShareableListItemsForUser(
   listIds: number[] | bigint[]
 ): Promise<number> {
   const batchResult = await db.listItem.deleteMany({
@@ -91,23 +89,19 @@ async function deleteShareableListUserData(
   // to the db
   if (shareableListIds.length === 0) {
     return `No shareable list data to delete for User ID: ${userId} (requestId='${requestId}')`;
-  } else if (shareableListIds.length > 0) {
-    // First, delete all list items if there are any
-    await deleteShareableListItemsForUser(shareableListIds);
-    // Now, delete all lists
-    await db.list
-      .deleteMany({
-        where: { userId },
-      })
-      .catch((error) => {
-        // some unexpected DB error, log to Sentry, but don't halt program
-        Sentry.captureException(
-          'Failed to delete shareable list data: ',
-          error
-        );
-      });
-    return `Deleting shareable lists data for User ID: ${userId} (requestId='${requestId}')`;
   }
+  // First, delete all list items if there are any
+  await deleteShareableListItemsForUser(shareableListIds);
+  // Now, delete all lists
+  await db.list
+    .deleteMany({
+      where: { userId },
+    })
+    .catch((error) => {
+      // some unexpected DB error, log to Sentry, but don't halt program
+      Sentry.captureException('Failed to delete shareable list data: ', error);
+    });
+  return `Deleting shareable lists data for User ID: ${userId} (requestId='${requestId}')`;
 }
 
 router.post(
@@ -129,11 +123,11 @@ router.post(
       .catch((e) => {
         // In the unlikely event that an error is thrown,
         // log to Sentry but don't halt program
+        Sentry.captureException(e);
         return res.send({
           status: 'BAD_REQUEST',
           message: e,
         });
-        Sentry.captureException(e);
       });
   }
 );

--- a/src/public/routes/deleteUserData.ts
+++ b/src/public/routes/deleteUserData.ts
@@ -9,12 +9,6 @@ const router = Router();
 const db = client();
 
 const deleteUserDataSchema: Schema = {
-  traceId: {
-    in: ['body'],
-    optional: true,
-    isString: true,
-    notEmpty: true,
-  },
   userId: {
     in: ['body'],
     errorMessage: 'Must provide valid userId',
@@ -78,17 +72,15 @@ export async function deleteShareableListItemsForUser(
 /**
  * This method deletes all shareable list data for a user
  * @param userId
- * @param requestId
  */
 async function deleteShareableListUserData(
-  userId: number | bigint,
-  requestId: string
+  userId: number | bigint
 ): Promise<string> {
   const shareableListIds = await getAllShareableListIdsForUser(userId);
   // if there are no lists found for a userId, lets not make unecessary calls
   // to the db
   if (shareableListIds.length === 0) {
-    return `No shareable list data to delete for User ID: ${userId} (requestId='${requestId}')`;
+    return `No shareable list data to delete for User ID: ${userId})`;
   }
   // First, delete all list items if there are any
   await deleteShareableListItemsForUser(shareableListIds);
@@ -101,7 +93,7 @@ async function deleteShareableListUserData(
       // some unexpected DB error, log to Sentry, but don't halt program
       Sentry.captureException('Failed to delete shareable list data: ', error);
     });
-  return `Deleting shareable lists data for User ID: ${userId} (requestId='${requestId}')`;
+  return `Deleting shareable lists data for User ID: ${userId})`;
 }
 
 router.post(
@@ -109,11 +101,10 @@ router.post(
   checkSchema(deleteUserDataSchema),
   validate,
   (req: Request, res: Response) => {
-    const requestId = req.body.traceId ?? nanoid();
     const userId = req.body.userId;
 
     // Delete all shareable lists data for userId from DB
-    deleteShareableListUserData(userId, requestId)
+    deleteShareableListUserData(userId)
       .then((result) => {
         return res.send({
           status: 'OK',

--- a/src/public/routes/deleteUserData.ts
+++ b/src/public/routes/deleteUserData.ts
@@ -3,7 +3,6 @@ import { Router } from 'express';
 import { checkSchema, Schema, validationResult } from 'express-validator';
 import * as Sentry from '@sentry/node';
 import { client } from '../../database/client';
-import { nanoid } from 'nanoid';
 
 const router = Router();
 const db = client();


### PR DESCRIPTION
## Goal

Legal said we don't need to retain any data. When a user deletes their account, `/deleteUserData` endpoint will delete all shareable list data from the db for that user. Added integration test for `/deleteUserData` endpoint.

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-386](https://getpocket.atlassian.net/browse/OSL-386)
