### PR TITLE
OSL-423: removing xss library, switching to using entities library for HTML encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "aws-xray-sdk-core": "3.4.1",
         "aws-xray-sdk-express": "3.4.1",
         "cors": "2.8.5",
+        "entities": "^4.5.0",
         "express": "4.18.2",
         "express-validator": "^6.15.0",
         "graphql": "16.6.0",
@@ -30,8 +31,7 @@
         "keyv": "^4.5.2",
         "sinon": "^15.0.1",
         "slugify": "1.6.6",
-        "uuid": "9.0.0",
-        "xss": "^1.0.14"
+        "uuid": "9.0.0"
       },
       "devDependencies": {
         "@faker-js/faker": "7.6.0",
@@ -4276,6 +4276,17 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "aws-xray-sdk-core": "3.4.1",
     "aws-xray-sdk-express": "3.4.1",
     "cors": "2.8.5",
+    "entities": "^4.5.0",
     "express": "4.18.2",
     "express-validator": "^6.15.0",
     "graphql": "16.6.0",
@@ -46,8 +47,7 @@
     "keyv": "^4.5.2",
     "sinon": "^15.0.1",
     "slugify": "1.6.6",
-    "uuid": "9.0.0",
-    "xss": "^1.0.14"
+    "uuid": "9.0.0"
   },
   "devDependencies": {
     "@faker-js/faker": "7.6.0",

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -169,11 +169,11 @@ describe('public mutations: ShareableList', () => {
         });
 
       expect(result.body.data.createShareableList.title).to.equal(
-        'My list to share&lt;script&gt;alert("Hello World!")&lt;/script&gt;'
+        'My list to share&lt;script&gt;alert(&quot;Hello World!&quot;)&lt;/script&gt;'
       );
 
       expect(result.body.data.createShareableList.description).to.equal(
-        'A description to share&lt;script&gt;alert("Hello World!")&lt;/script&gt;'
+        'A description to share&lt;script&gt;alert(&quot;Hello World!&quot;)&lt;/script&gt;'
       );
     });
 
@@ -295,14 +295,15 @@ describe('public mutations: ShareableList', () => {
     });
 
     it('should not create List with existing title for the same userId', async () => {
-      const list1 = await createShareableListHelper(db, {
-        title: `Katerina's List`,
+      // store list title in db encoded
+      await createShareableListHelper(db, {
+        title: `Katerina&apos;s List`,
         userId: parseInt(headers.userId),
       });
-      const title1 = list1.title;
       // create new List with title1 value for the same user
+      // let also make sure the list title gets encoded properly if special chars
       const data: CreateShareableListInput = {
-        title: title1,
+        title: `Katerina's List`,
         description: faker.lorem.sentences(2),
       };
       const result = await request(app)
@@ -316,7 +317,7 @@ describe('public mutations: ShareableList', () => {
       expect(result.body.errors.length).to.equal(1);
       expect(result.body.errors[0].extensions.code).to.equal('BAD_USER_INPUT');
       expect(result.body.errors[0].message).to.equal(
-        `A list with the title "Katerina's List" already exists`
+        `A list with the title "Katerina&apos;s List" already exists`
       );
     });
 

--- a/src/public/resolvers/utils.spec.ts
+++ b/src/public/resolvers/utils.spec.ts
@@ -48,7 +48,7 @@ describe('utility functions', () => {
       }).not.to.throw();
     });
   });
-  describe('xssifyMutationInput', () => {
+  describe('sanitizeMutationInput', () => {
     it('transforms strings in a mutation input object', () => {
       const input: CreateShareableListInput = {
         title: 'My <first> list',
@@ -60,7 +60,7 @@ describe('utility functions', () => {
 
       expect(safeInput.title).to.equal('My &lt;first&gt; list');
       expect(safeInput.description).to.equal(
-        'Trying out this new Pocket feature&lt;script&gt;alert("!!!");&lt;/script&gt;'
+        'Trying out this new Pocket feature&lt;script&gt;alert(&quot;!!!&quot;);&lt;/script&gt;'
       );
     });
 
@@ -81,7 +81,7 @@ describe('utility functions', () => {
 
       // dodgy strings are still escaped
       expect(safeInput.imageUrl).to.equal(
-        'https://www.test.com/&lt;script&gt;alert("hello world");&lt;/script&gt;'
+        'https://www.test.com/&lt;script&gt;alert(&quot;hello world&quot;);&lt;/script&gt;'
       );
 
       // numeric inputs go through as-is

--- a/src/public/resolvers/utils.ts
+++ b/src/public/resolvers/utils.ts
@@ -1,11 +1,12 @@
-import xss from 'xss';
-
+/* eslint @typescript-eslint/no-var-requires: "off" */
 import { PrismaClient } from '@prisma/client';
 import { ForbiddenError, UserInputError } from '@pocket-tools/apollo-utils';
 
 import { IPublicContext } from '../context';
 import { ACCESS_DENIED_ERROR } from '../../shared/constants';
 import { isPilotUser } from '../../database/queries';
+
+const entities = require('entities');
 
 /**
  * Executes a mutation, catches exceptions and records to sentry and console
@@ -39,10 +40,12 @@ export function sanitizeMutationInput<InputType>(input: InputType): InputType {
 
     Object.entries(input).forEach(([key, value]) => {
       // Only transform string values
-      sanitizedInput[key] = typeof value === 'string' ? xss(value) : value;
+      sanitizedInput[key] =
+        typeof value === 'string' ? entities.escapeUTF8(value) : value;
     });
   } else {
-    sanitizedInput = typeof input === 'string' ? xss(input) : input;
+    sanitizedInput =
+      typeof input === 'string' ? entities.escapeUTF8(input) : input;
   }
 
   return sanitizedInput;


### PR DESCRIPTION
## Goal

`xss` package doesn't seem to be consistent, so switching to `entities` package.

## Tickets

- More details here: [https://getpocket.atlassian.net/browse/OSL-423](https://getpocket.atlassian.net/browse/OSL-423)
