### PR TITLE
OSL-423: replace < and > with encoded chars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,7 @@
         "keyv": "^4.5.2",
         "sinon": "^15.0.1",
         "slugify": "1.6.6",
-        "uuid": "9.0.0",
-        "xss": "^1.0.14"
+        "uuid": "9.0.0"
       },
       "devDependencies": {
         "@faker-js/faker": "7.6.0",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "keyv": "^4.5.2",
     "sinon": "^15.0.1",
     "slugify": "1.6.6",
-    "uuid": "9.0.0",
-    "xss": "^1.0.14"
+    "uuid": "9.0.0"
   },
   "devDependencies": {
     "@faker-js/faker": "7.6.0",

--- a/src/public/resolvers/utils.spec.ts
+++ b/src/public/resolvers/utils.spec.ts
@@ -48,17 +48,17 @@ describe('utility functions', () => {
       }).not.to.throw();
     });
   });
-  describe('xssifyMutationInput', () => {
+  describe('sanitizeMutationInput', () => {
     it('transforms strings in a mutation input object', () => {
       const input: CreateShareableListInput = {
-        title: 'My <first> list',
+        title: `John's <div> list </div>`,
         description:
           'Trying out this new Pocket feature<script>alert("!!!");</script>',
       };
 
       const safeInput = sanitizeMutationInput(input);
 
-      expect(safeInput.title).to.equal('My &lt;first&gt; list');
+      expect(safeInput.title).to.equal(`John's &lt;div&gt; list &lt;/div&gt;`);
       expect(safeInput.description).to.equal(
         'Trying out this new Pocket feature&lt;script&gt;alert("!!!");&lt;/script&gt;'
       );

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -10,3 +10,6 @@ export const PRISMA_RECORD_NOT_FOUND = 'P2025';
 export const LIST_TITLE_MAX_CHARS = 100;
 
 export const LIST_DESCRIPTION_MAX_CHARS = 200;
+
+export const GT_ENCODED = '&gt;'; // >
+export const LT_ENCODED = '&lt;'; // <


### PR DESCRIPTION
## Goal

As discussed, if using the `entities` library to use HTML encoding, `Katerina's List` transforms to `Katerina&apos; List` and the generated slug when the list is published is `katerinaapos-list`. We want to avoid this, so for now we are only encoding `<` and `>`.

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-423](https://getpocket.atlassian.net/browse/OSL-423)

## Implementation Decisions

Decided to write a small function to find and replace chars in a str which can be reused in other methods if needed.
