### PR TITLE
chore(elasticache): update elasticache node type based on usage/price

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -16,9 +16,8 @@ const githubConnectionArn = isDev
 const branch = isDev ? 'dev' : 'main';
 const eventBusName = `PocketEventBridge-${environment}-Shared-Event-Bus`;
 
-//Arbitrary size and count for cache. No logic was used in deciding this.
 const cacheNodes = isDev ? 2 : 2;
-const cacheSize = isDev ? 'cache.t2.micro' : 'cache.t3.medium';
+const cacheSize = isDev ? 'cache.t3.micro' : 'cache.t3.micro';
 
 export const config = {
   name,


### PR DESCRIPTION
## Goal

Reviewed usage and node types now available for Elasticache, recommend using t3.micro for both dev and prod

Documentation:
 -  https://docs.google.com/spreadsheets/d/1IqqRjPTBniE3xTCZytm1Z52_iCwH_jFKHjHDZSPHhLs/edit#gid=0
