### PR TITLE
OSL-472: adding listRestorationReason field to db, updating resolvers and tests

### DIFF
--- a/prisma/migrations/20230427220337_add_list_restoration_details/migration.sql
+++ b/prisma/migrations/20230427220337_add_list_restoration_details/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `List` ADD COLUMN `listRestorationReason` TEXT NULL;

--- a/prisma/migrations/20230427220337_add_list_restoration_details/migration.sql
+++ b/prisma/migrations/20230427220337_add_list_restoration_details/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE `List` ADD COLUMN `listRestorationReason` TEXT NULL;

--- a/prisma/migrations/20230501175820_add_restoration_reason_to_list/migration.sql
+++ b/prisma/migrations/20230501175820_add_restoration_reason_to_list/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `List` ADD COLUMN `restorationReason` TEXT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,7 +34,7 @@ model List {
   moderatedBy             String?          @db.VarChar(255)
   moderationReason        String?          @db.Text
   moderationDetails       String?          @db.Text
-  listRestorationReason   String?          @db.Text
+  restorationReason       String?          @db.Text
   listItemNoteVisibility  Visibility       @default(PRIVATE)
   createdAt               DateTime         @default(now()) @db.DateTime(0)
   updatedAt               DateTime         @updatedAt

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,7 @@ model List {
   moderatedBy             String?          @db.VarChar(255)
   moderationReason        String?          @db.Text
   moderationDetails       String?          @db.Text
+  listRestorationReason   String?          @db.Text
   listItemNoteVisibility  Visibility       @default(PRIVATE)
   createdAt               DateTime         @default(now()) @db.DateTime(0)
   updatedAt               DateTime         @updatedAt

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -81,6 +81,10 @@ type ShareableListComplete implements ShareableListInterface {
   The optional details why the list was moderated.
   """
   moderationDetails: String
+  """
+  The reason why a list was restored (set from hidden to visible).
+  """
+  listRestorationReason: String
 }
 
 type Query {
@@ -96,8 +100,9 @@ Input data for removing (moderating) a ShareableList
 input ModerateShareableListInput {
   externalId: ID!
   moderationStatus: ShareableListModerationStatus!
-  moderationReason: ShareableListModerationReason!
+  moderationReason: ShareableListModerationReason
   moderationDetails: String
+  listRestorationReason: String
 }
 
 type Mutation {

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -84,7 +84,7 @@ type ShareableListComplete implements ShareableListInterface {
   """
   The reason why a list was restored (set from hidden to visible).
   """
-  listRestorationReason: String
+  restorationReason: String
 }
 
 type Query {
@@ -102,7 +102,7 @@ input ModerateShareableListInput {
   moderationStatus: ShareableListModerationStatus!
   moderationReason: ShareableListModerationReason
   moderationDetails: String
-  listRestorationReason: String
+  restorationReason: String
 }
 
 type Mutation {

--- a/src/admin/resolvers/fragments.gql.ts
+++ b/src/admin/resolvers/fragments.gql.ts
@@ -14,6 +14,7 @@ export const ShareableListCompleteProps = gql`
     moderatedBy
     moderationReason
     moderationDetails
+    listRestorationReason
     listItems {
       ...ShareableListItemPublicProps
     }

--- a/src/admin/resolvers/fragments.gql.ts
+++ b/src/admin/resolvers/fragments.gql.ts
@@ -14,7 +14,7 @@ export const ShareableListCompleteProps = gql`
     moderatedBy
     moderationReason
     moderationDetails
-    listRestorationReason
+    restorationReason
     listItems {
       ...ShareableListItemPublicProps
     }

--- a/src/admin/resolvers/mutations/ShareableList.integration.ts
+++ b/src/admin/resolvers/mutations/ShareableList.integration.ts
@@ -147,7 +147,7 @@ describe('admin mutations: ShareableList', () => {
       expect(moderatedList.moderationReason).to.equal(data.moderationReason);
       expect(moderatedList.moderationDetails).to.equal(data.moderationDetails);
     });
-    it('will fail to restore list if listRestorationReason is not passed', async () => {
+    it('will fail to restore list if restorationReason is not passed', async () => {
       const theList = await createShareableListHelper(db, {
         userId: 12345,
         title: 'Moderate this list',
@@ -157,7 +157,7 @@ describe('admin mutations: ShareableList', () => {
       const data = {
         externalId: theList.externalId,
         moderationStatus: 'VISIBLE',
-        listRestorationReason: '\n', // should not consider this as valid input
+        restorationReason: '\n', // should not consider this as valid input
       };
       const result = await request(app)
         .post(graphQLUrl)
@@ -181,7 +181,7 @@ describe('admin mutations: ShareableList', () => {
       const data = {
         externalId: theList.externalId,
         moderationStatus: 'VISIBLE',
-        listRestorationReason: 'making list visible now',
+        restorationReason: 'making list visible now',
       };
       const result = await request(app)
         .post(graphQLUrl)
@@ -196,9 +196,7 @@ describe('admin mutations: ShareableList', () => {
       expect(moderatedList).to.not.be.null;
       expect(moderatedList.externalId).to.equal(theList.externalId);
       expect(moderatedList.moderationStatus).to.equal(data.moderationStatus);
-      expect(moderatedList.listRestorationReason).to.equal(
-        data.listRestorationReason
-      );
+      expect(moderatedList.restorationReason).to.equal(data.restorationReason);
     });
     it('moderationDetails is optional', async () => {
       const theList = await createShareableListHelper(db, {

--- a/src/admin/resolvers/mutations/ShareableList.ts
+++ b/src/admin/resolvers/mutations/ShareableList.ts
@@ -36,16 +36,15 @@ export async function moderateShareableList(
       throw new UserInputError(`Moderation reason required.`);
     }
   }
-  // if list is set to visible, enforce listRestorationReason is also passed
+  // if list is set to visible, enforce restorationReason is also passed
   if (data.moderationStatus === ModerationStatus.VISIBLE) {
     if (
-      !data.listRestorationReason ||
-      (data.listRestorationReason &&
-        data.listRestorationReason.trim().length === 0)
+      !data.restorationReason ||
+      (data.restorationReason && data.restorationReason.trim().length === 0)
     ) {
       throw new UserInputError(`List restoration reason required.`);
     }
-    data.listRestorationReason = data.listRestorationReason.trim();
+    data.restorationReason = data.restorationReason.trim();
   }
   return await dbModerateShareableList(db, data);
 }

--- a/src/admin/resolvers/mutations/ShareableList.ts
+++ b/src/admin/resolvers/mutations/ShareableList.ts
@@ -1,4 +1,5 @@
-import { ForbiddenError } from '@pocket-tools/apollo-utils';
+import { ForbiddenError, UserInputError } from '@pocket-tools/apollo-utils';
+import { ModerationStatus } from '@prisma/client';
 import { ACCESS_DENIED_ERROR } from '../../../shared/constants';
 import { ShareableListComplete } from '../../../database/types';
 import { moderateShareableList as dbModerateShareableList } from '../../../database/mutations';
@@ -28,6 +29,23 @@ export async function moderateShareableList(
   data.moderatedBy = authenticatedUser.username;
   if (data.moderationDetails) {
     data.moderationDetails = data.moderationDetails.trim();
+  }
+  // if list is set to hidden, enforce moderationReason is also passed
+  if (data.moderationStatus === ModerationStatus.HIDDEN) {
+    if (!data.moderationReason) {
+      throw new UserInputError(`Moderation reason required.`);
+    }
+  }
+  // if list is set to visible, enforce listRestorationReason is also passed
+  if (data.moderationStatus === ModerationStatus.VISIBLE) {
+    if (
+      !data.listRestorationReason ||
+      (data.listRestorationReason &&
+        data.listRestorationReason.trim().length === 0)
+    ) {
+      throw new UserInputError(`List restoration reason required.`);
+    }
+    data.listRestorationReason = data.listRestorationReason.trim();
   }
   return await dbModerateShareableList(db, data);
 }

--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -212,6 +212,7 @@ export async function moderateShareableList(
       isShareableListEventType: true,
     });
   }
+  // TODO: send shareable-list-visible event to Snowplow - OSL-473
   return list;
 }
 

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -90,7 +90,7 @@ const shareableListCompleteSelectFields = {
   moderatedBy: true,
   moderationReason: true,
   moderationDetails: true,
-  listRestorationReason: true,
+  restorationReason: true,
 };
 const shareableListComplete = Prisma.validator<Prisma.ListArgs>()({
   select: shareableListCompleteSelectFields,
@@ -123,7 +123,7 @@ export type ModerateShareableListInput = {
   // optional here, but enforced on the front-end
   moderationReason?: ShareableListModerationReason;
   moderationDetails?: string;
-  listRestorationReason?: string;
+  restorationReason?: string;
   // not in the schema, copied from the request user data when updating
   moderatedBy: string;
 };

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -90,6 +90,7 @@ const shareableListCompleteSelectFields = {
   moderatedBy: true,
   moderationReason: true,
   moderationDetails: true,
+  listRestorationReason: true,
 };
 const shareableListComplete = Prisma.validator<Prisma.ListArgs>()({
   select: shareableListCompleteSelectFields,
@@ -119,8 +120,10 @@ export type UpdateShareableListInput = {
 export type ModerateShareableListInput = {
   externalId: string;
   moderationStatus: ModerationStatus;
-  moderationReason: ShareableListModerationReason;
+  // optional here, but enforced on the front-end
+  moderationReason?: ShareableListModerationReason;
   moderationDetails?: string;
+  listRestorationReason?: string;
   // not in the schema, copied from the request user data when updating
   moderatedBy: string;
 };

--- a/src/snowplow/events.spec.ts
+++ b/src/snowplow/events.spec.ts
@@ -34,7 +34,7 @@ describe('Snowplow event helpers', () => {
     moderatedBy: null,
     moderationReason: null,
     moderationDetails: null,
-    listRestorationReason: null,
+    restorationReason: null,
     createdAt: new Date('2023-01-01 10:10:10'),
     updatedAt: new Date('2023-01-01 10:10:10'),
     listItems: [],

--- a/src/snowplow/events.spec.ts
+++ b/src/snowplow/events.spec.ts
@@ -34,6 +34,7 @@ describe('Snowplow event helpers', () => {
     moderatedBy: null,
     moderationReason: null,
     moderationDetails: null,
+    listRestorationReason: null,
     createdAt: new Date('2023-01-01 10:10:10'),
     updatedAt: new Date('2023-01-01 10:10:10'),
     listItems: [],


### PR DESCRIPTION
## Goal

Adding a new optional field to the List obj `listRestorationReason` to contain the reason why a list was restored by a moderator (moderation status from hidden to visible). See [slack thread](https://pocket.slack.com/archives/C04HWMUKLN5/p1682626870569429) here.

* Added optional field to prisma schema.
* Added the field as an optional param to the admin graphQL schema.
* `moderationReason` is now optional on the graph level for the `ModerateShareableInput` type but enforced in the resolver when list is set to hidden.
* `listRestoration` is also optional on the graph level for the `ModerateShareableInput` type but enforced in the resolver when list is set to visible.
* Updated tests.

For now, we will not store historical moderation data in the db, and overwrite the moderation fields if a single list is being moderated back and forth.

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-472](https://getpocket.atlassian.net/browse/OSL-472)
