### PR TITLE
OSL-478: Adding updateShareableListItems mutation for bulk edit feat

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
   provider      = "prisma-client-js"
   binaryTargets = ["native", "debian-openssl-1.1.x"]
+  previewFeatures = ["interactiveTransactions"]
 }
 
 datasource db {

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -151,10 +151,21 @@ input CreateShareableListItemWithList {
   sortOrder: Int!
 }
 
+"""
+Input data for updating a single Shareable List Item.
+"""
 input UpdateShareableListItemInput {
   externalId: ID!
   note: String @constraint(maxLength: 300)
   sortOrder: Int
+}
+
+"""
+Input data for updating an array of Shareable List Items, targeting sortOrder.
+"""
+input UpdateShareableListItemsInput {
+  externalId: ID!
+  sortOrder: Int!
 }
 
 type Query {
@@ -203,11 +214,17 @@ type Mutation {
     data: CreateShareableListItemInput!
   ): ShareableListItem
   """
-  Updates a Shareable List Item.
+  Updates a single Shareable List Item.
   """
   updateShareableListItem(
     data: UpdateShareableListItemInput!
   ): ShareableListItem!
+  """
+  Updates an array of Shareable List Items (sortOrder).
+  """
+  updateShareableListItems(
+    data: [UpdateShareableListItemsInput!]!
+  ): [ShareableListItem!]!
   """
   Deletes a Shareable List Item. HIDDEN Lists cannot have their items deleted.
   """

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -224,6 +224,7 @@ type Mutation {
   """
   updateShareableListItems(
     data: [UpdateShareableListItemsInput!]!
+      @constraint(minItems: 1, maxItems: 30)
   ): [ShareableListItem!]!
   """
   Deletes a Shareable List Item. HIDDEN Lists cannot have their items deleted.

--- a/src/database/mutations.ts
+++ b/src/database/mutations.ts
@@ -9,4 +9,5 @@ export {
   createShareableListItem,
   deleteShareableListItem,
   updateShareableListItem,
+  updateShareableListItems,
 } from './mutations/ShareableListItem';

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -141,8 +141,19 @@ export type CreateShareableListItemInput = {
   sortOrder: number;
 };
 
+/**
+ * Input for updating a single shareable list item
+ */
 export type UpdateShareableListItemInput = {
   externalId: string;
   note?: string;
   sortOrder?: number;
+};
+
+/**
+ * Input for updating an array of shareable list items
+ */
+export type UpdateShareableListItemsInput = {
+  externalId: string;
+  sortOrder: number;
 };

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -16,6 +16,7 @@ import {
   createShareableListItem,
   deleteShareableListItem,
   updateShareableListItem,
+  updateShareableListItems,
 } from './mutations/ShareableListItem';
 
 export const resolvers = {
@@ -35,6 +36,7 @@ export const resolvers = {
     updateShareableList,
     createShareableListItem,
     updateShareableListItem,
+    updateShareableListItems,
     deleteShareableListItem,
   },
   Query: {

--- a/src/public/resolvers/mutations/ShareableListItem.ts
+++ b/src/public/resolvers/mutations/ShareableListItem.ts
@@ -3,11 +3,13 @@ import {
   CreateShareableListItemInput,
   ShareableListItem,
   UpdateShareableListItemInput,
+  UpdateShareableListItemsInput,
 } from '../../../database/types';
 import {
   createShareableListItem as dbCreateShareableListItem,
   deleteShareableListItem as dbDeleteShareableListItem,
   updateShareableListItem as dbUpdateShareableListItem,
+  updateShareableListItems as dbUpdateShareableListItems,
 } from '../../../database/mutations';
 import { executeMutation } from '../utils';
 
@@ -43,6 +45,22 @@ export async function updateShareableListItem(
     data,
     dbUpdateShareableListItem
   );
+}
+
+/**
+ * @param parent not used
+ * @param data UpdateShareableListItemsInput
+ * @param context IPublicContext
+ */
+export async function updateShareableListItems(
+  parent,
+  { data },
+  context: IPublicContext
+): Promise<ShareableListItem[]> {
+  return await executeMutation<
+    UpdateShareableListItemsInput[],
+    ShareableListItem[]
+  >(context, data, dbUpdateShareableListItems);
 }
 
 /**

--- a/src/public/resolvers/mutations/sample-mutations.gql.ts
+++ b/src/public/resolvers/mutations/sample-mutations.gql.ts
@@ -52,6 +52,15 @@ export const UPDATE_SHAREABLE_LIST_ITEM = gql`
   ${ShareableListItemPublicProps}
 `;
 
+export const UPDATE_SHAREABLE_LIST_ITEMS = gql`
+  mutation updateShareableListItems($data: [UpdateShareableListItemsInput!]!) {
+    updateShareableListItems(data: $data) {
+      ...ShareableListItemPublicProps
+    }
+  }
+  ${ShareableListItemPublicProps}
+`;
+
 export const DELETE_SHAREABLE_LIST_ITEM = gql`
   mutation deleteShareableListItem($externalId: ID!) {
     deleteShareableListItem(externalId: $externalId) {


### PR DESCRIPTION
## Goal

Adding a new `updateShareableListItems` mutation which accepts an array of shareable list item `sortOrder`. This is for bulk edit/ reorder effort.

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-478](https://getpocket.atlassian.net/browse/OSL-478)

## Implementation Decisions

According to this [known issue](https://github.com/prisma/prisma/issues/6862), it is not possible to use the `updateMany` prisma call to update several rows with different values, so using the [transactions API ](https://www.prisma.io/docs/guides/performance-and-optimization/prisma-client-transactions-guide#transaction-api)to perform the bulk update.
