### PR TITLE
fix(listItem sort): return listItems by sortOrder

### DIFF
--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -160,7 +160,16 @@ export async function updateShareableList(
     data,
     where: { externalId: data.externalId },
     include: {
-      listItems: true,
+      listItems: {
+        orderBy: [
+          {
+            sortOrder: 'asc',
+          },
+          {
+            createdAt: 'asc',
+          },
+        ],
+      },
     },
   });
 
@@ -195,7 +204,15 @@ export async function moderateShareableList(
     .update({
       data: data,
       where: { externalId: data.externalId },
-      include: { listItems: true },
+      include: {
+        listItems: {
+          orderBy: [
+            {
+              sortOrder: 'asc',
+            },
+          ],
+        },
+      },
     })
     .catch((error) => {
       if (error.code === PRISMA_RECORD_NOT_FOUND) {

--- a/src/database/queries/ShareableList.ts
+++ b/src/database/queries/ShareableList.ts
@@ -4,7 +4,7 @@ import { ForbiddenError, NotFoundError } from '@pocket-tools/apollo-utils';
 import { ACCESS_DENIED_ERROR } from '../../shared/constants';
 
 /**
- * This is a public query, which is why we only return
+ * This is an authenticated query, which is why we only return
  * a subset of ShareableList properties.
  * Retrieves a single list for a given userId from the datastore.
  *
@@ -26,14 +26,23 @@ export function getShareableList(
       moderationStatus: ModerationStatus.VISIBLE,
     },
     include: {
-      listItems: true,
+      listItems: {
+        orderBy: [
+          {
+            sortOrder: 'asc',
+          },
+          {
+            createdAt: 'asc',
+          },
+        ],
+      },
     },
   });
 }
 
 /**
- * This query returns a publicly viewable Shareable List,
- * retrieved by its external ID
+ * This query returns a publicly viewable Shareable List retrieved by its
+ * external ID and slug.
  *
  * @param db
  * @param externalId
@@ -53,7 +62,16 @@ export async function getShareableListPublic(
       status: Visibility.PUBLIC,
     },
     include: {
-      listItems: true,
+      listItems: {
+        orderBy: [
+          {
+            sortOrder: 'asc',
+          },
+          {
+            createdAt: 'asc',
+          },
+        ],
+      },
     },
   });
 
@@ -97,7 +115,16 @@ export function getShareableLists(
     },
     orderBy: { updatedAt: 'desc' },
     include: {
-      listItems: true,
+      listItems: {
+        orderBy: [
+          {
+            sortOrder: 'asc',
+          },
+          {
+            createdAt: 'asc',
+          },
+        ],
+      },
     },
   });
 }
@@ -118,7 +145,16 @@ export function searchShareableList(
       externalId,
     },
     include: {
-      listItems: true,
+      listItems: {
+        orderBy: [
+          {
+            sortOrder: 'asc',
+          },
+          {
+            createdAt: 'asc',
+          },
+        ],
+      },
     },
   });
 }

--- a/src/test/helpers/createShareableListItemHelper.ts
+++ b/src/test/helpers/createShareableListItemHelper.ts
@@ -37,7 +37,8 @@ export async function createShareableListItemHelper(
     imageUrl: data.imageUrl ?? faker.image.cats(),
     publisher: data.publisher ?? faker.company.name(),
     authors: data.authors ?? faker.name.fullName(),
-    sortOrder: data.sortOrder ?? faker.datatype.number(),
+    // allow sortOrder to fall back to db default if no specific order given
+    sortOrder: data.sortOrder ?? undefined,
   };
 
   return await prisma.listItem.create({


### PR DESCRIPTION
## Goal

return listItems by `sortOrder`

- specify fallback sorting by createdAt ascending (which was default)

## Tickets

- https://getpocket.atlassian.net/browse/OSL-425