### PR TITLE
OSL-397-OSL-473: send new fields to snowplow 

### DIFF
--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -212,7 +212,12 @@ export async function moderateShareableList(
       isShareableListEventType: true,
     });
   }
-  // TODO: send shareable-list-visible event to Snowplow - OSL-473
+  if (data.moderationStatus === ModerationStatus.VISIBLE) {
+    sendEventHelper(EventBridgeEventType.SHAREABLE_LIST_UNHIDDEN, {
+      shareableList: list as ShareableListComplete,
+      isShareableListEventType: true,
+    });
+  }
   return list;
 }
 

--- a/src/snowplow/events.ts
+++ b/src/snowplow/events.ts
@@ -40,6 +40,7 @@ function transformAPIShareableListToSnowplowShareableList(
       ? shareableList.description
       : undefined,
     status: shareableList.status,
+    list_item_note_visibility: shareableList.listItemNoteVisibility,
     moderation_status: shareableList.moderationStatus,
     moderated_by: shareableList.moderatedBy
       ? shareableList.moderatedBy
@@ -49,6 +50,9 @@ function transformAPIShareableListToSnowplowShareableList(
       : undefined,
     moderation_details: shareableList.moderationDetails
       ? shareableList.moderationDetails
+      : undefined,
+    restoration_reason: shareableList.restorationReason
+      ? shareableList.restorationReason
       : undefined,
     created_at: Math.floor(shareableList.createdAt.getTime() / 1000),
     updated_at: shareableList.updatedAt
@@ -83,6 +87,7 @@ function transformAPIShareableListItemToSnowplowShareableListItem(
     publisher: shareableListItem.publisher
       ? shareableListItem.publisher
       : undefined,
+    note: shareableListItem.note ? shareableListItem.note : undefined,
     sort_order: shareableListItem.sortOrder,
     created_at: Math.floor(shareableListItem.createdAt.getTime() / 1000),
     updated_at: shareableListItem.updatedAt

--- a/src/snowplow/types.ts
+++ b/src/snowplow/types.ts
@@ -16,9 +16,11 @@ export enum EventBridgeEventType {
   SHAREABLE_LIST_UPDATED = 'shareable_list_updated',
   SHAREABLE_LIST_DELETED = 'shareable_list_deleted',
   SHAREABLE_LIST_HIDDEN = 'shareable_list_hidden',
+  SHAREABLE_LIST_UNHIDDEN = 'shareable_list_unhidden',
   SHAREABLE_LIST_PUBLISHED = 'shareable_list_published',
   SHAREABLE_LIST_UNPUBLISHED = 'shareable_list_unpublished',
   SHAREABLE_LIST_ITEM_CREATED = 'shareable_list_item_created',
+  SHAREABLE_LIST_ITEM_UPDATED = 'shareable_list_item_updated',
   SHAREABLE_LIST_ITEM_DELETED = 'shareable_list_item_deleted',
 }
 
@@ -41,10 +43,12 @@ export type SnowplowShareableList = {
   title: string;
   description?: string;
   status: Visibility;
+  list_item_note_visibility: Visibility;
   moderation_status: ModerationStatus;
   moderated_by?: string;
   moderation_reason?: string;
   moderation_details?: string;
+  restoration_reason?: string;
   created_at: number; // snowplow schema requires this field in seconds
   updated_at?: number; // snowplow schema requires this field in seconds
 };
@@ -61,6 +65,7 @@ export type SnowplowShareableListItem = {
   image_url?: string;
   authors?: string[];
   publisher?: string;
+  note?: string;
   sort_order: number;
   created_at: number; // snowplow schema requires this field in seconds
   updated_at?: number; // snowplow schema requires this field in seconds


### PR DESCRIPTION
## Goal

* Send `restorationReason` and `note` fields to Snowplow
* Add `shareable_list-unhidden` & `shareable_list_item_updated` triggers
* Update snowplow unit test

## Todos

- [ ] lets test in dev first

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-397](https://getpocket.atlassian.net/browse/OSL-397)
- [https://getpocket.atlassian.net/browse/OSL-473](https://getpocket.atlassian.net/browse/OSL-473)
