### PR TITLE
feat(parser Item): reference parser Item from shareable list item

### DIFF
--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -59,6 +59,13 @@ type User @key(fields: "id", resolvable: false) {
 }
 
 """
+Resolve by reference the Item entity to connect ShareableListItems to Items.
+"""
+type Item @key(fields: "itemId", resolvable: false) {
+  itemId: String!
+}
+
+"""
 A Pocket Save (story) that has been added to a Shareable List.
 """
 type ShareableListItem {
@@ -70,6 +77,10 @@ type ShareableListItem {
   The Parser Item ID.
   """
   itemId: ID!
+  """
+  The Parser Item
+  """
+  item: Item! @cacheControl(maxAge: 60, scope: PUBLIC)
   """
   The URL of the story saved to a list.
   """

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -1,5 +1,6 @@
 import { PocketDefaultScalars } from '@pocket-tools/apollo-utils';
 import { PrismaBigIntResolver } from '../../shared/resolvers/fields/PrismaBigInt';
+import { ItemResolver } from '../../shared/resolvers/fields/Item';
 import { UserResolver } from '../../shared/resolvers/fields/User';
 import {
   getShareableList,
@@ -29,6 +30,7 @@ export const resolvers = {
   },
   ShareableListItem: {
     itemId: PrismaBigIntResolver,
+    item: ItemResolver,
   },
   Mutation: {
     createShareableList,

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -272,6 +272,7 @@ describe('public mutations: ShareableList', () => {
       expect(listItem.title).to.equal(listItemData.title);
       expect(listItem.url).to.equal(listItemData.url);
       expect(listItem.itemId).to.equal(listItemData.itemId);
+      expect(listItem.item.itemId).to.equal(listItemData.itemId);
       expect(listItem.excerpt).to.equal(listItemData.excerpt);
       expect(listItem.imageUrl).to.equal(listItemData.imageUrl);
       expect(listItem.publisher).to.equal(listItemData.publisher);

--- a/src/public/resolvers/mutations/ShareableListItem.integration.ts
+++ b/src/public/resolvers/mutations/ShareableListItem.integration.ts
@@ -263,6 +263,7 @@ describe('public mutations: ShareableListItem', () => {
       const listItem = result.body.data.createShareableListItem;
       expect(listItem.externalId).not.to.be.empty;
       expect(listItem.itemId).to.equal(data.itemId);
+      expect(listItem.item.itemId).to.equal(data.itemId);
       expect(listItem.url).to.equal(data.url);
       expect(listItem.title).to.equal(data.title);
       expect(listItem.excerpt).to.equal(
@@ -313,6 +314,7 @@ describe('public mutations: ShareableListItem', () => {
 
       expect(listItem.externalId).not.to.be.empty;
       expect(listItem.itemId).to.equal(data.itemId);
+      expect(listItem.item.itemId).to.equal(data.itemId);
       expect(listItem.url).to.equal(data.url);
       expect(listItem.title).to.equal(data.title);
       expect(listItem.excerpt).to.equal(
@@ -405,6 +407,7 @@ describe('public mutations: ShareableListItem', () => {
       const listItem = result.body.data.createShareableListItem;
       expect(listItem.externalId).not.to.be.empty;
       expect(listItem.itemId).to.equal(data.itemId);
+      expect(listItem.item.itemId).to.equal(data.itemId);
       expect(listItem.url).to.equal(data.url);
       expect(listItem.title).to.equal(data.title);
       expect(listItem.excerpt).to.equal(data.excerpt);

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -224,6 +224,8 @@ describe('public queries: ShareableList', () => {
       // Let's run through the visible props of each item
       // to make sure they're all there
       listItems.forEach((listItem) => {
+        expect(listItem.itemId).not.to.be.empty;
+        expect(listItem.item.itemId).not.to.be.empty;
         expect(listItem.url).not.to.be.empty;
         expect(listItem.title).not.to.be.empty;
         expect(listItem.excerpt).not.to.be.empty;
@@ -460,6 +462,7 @@ describe('public queries: ShareableList', () => {
       // to make sure they're all there
       listItems.forEach((listItem) => {
         expect(listItem.itemId).not.to.be.empty;
+        expect(listItem.item.itemId).not.to.be.empty;
         expect(listItem.url).not.to.be.empty;
         expect(listItem.title).not.to.be.empty;
         expect(listItem.excerpt).not.to.be.empty;
@@ -528,6 +531,7 @@ describe('public queries: ShareableList', () => {
       // to make sure they're all there
       result.body.data.shareableListPublic.listItems.forEach((listItem) => {
         expect(listItem.itemId).not.to.be.empty;
+        expect(listItem.item.itemId).not.to.be.empty;
         expect(listItem.url).not.to.be.empty;
         expect(listItem.title).not.to.be.empty;
         expect(listItem.excerpt).not.to.be.empty;
@@ -680,6 +684,8 @@ describe('public queries: ShareableList', () => {
       // Let's run through the visible props of each item
       // to make sure they're all there for the first List
       listItems.forEach((listItem) => {
+        expect(listItem.itemId).not.to.be.empty;
+        expect(listItem.item.itemId).not.to.be.empty;
         expect(listItem.url).not.to.be.empty;
         expect(listItem.title).not.to.be.empty;
         expect(listItem.excerpt).not.to.be.empty;
@@ -700,6 +706,8 @@ describe('public queries: ShareableList', () => {
       // Let's run through the visible props of each item
       // to make sure they're all there for the second List
       listItems.forEach((listItem) => {
+        expect(listItem.itemId).not.to.be.empty;
+        expect(listItem.item.itemId).not.to.be.empty;
         expect(listItem.url).not.to.be.empty;
         expect(listItem.title).not.to.be.empty;
         expect(listItem.excerpt).not.to.be.empty;

--- a/src/shared/fragments.gql.ts
+++ b/src/shared/fragments.gql.ts
@@ -8,6 +8,9 @@ export const ShareableListItemPublicProps = gql`
   fragment ShareableListItemPublicProps on ShareableListItem {
     externalId
     itemId
+    item {
+      itemId
+    }
     url
     title
     excerpt

--- a/src/shared/resolvers/fields/Item.ts
+++ b/src/shared/resolvers/fields/Item.ts
@@ -1,0 +1,14 @@
+/**
+ * Return an object conforming to the Item graphql definition.
+ *
+ * @param parent // a ListItem
+ * @param args
+ * @param context
+ * @param info
+ */
+export const ItemResolver = (parent, args, context, info) => {
+  // very basic data transformation!
+  return {
+    itemId: parent.itemId.toString(),
+  };
+};


### PR DESCRIPTION
## Goal

reference parser Item from shareable list item.

## Tickets

- https://getpocket.atlassian.net/browse/OSL-482

## Implementation Decisions

not extending `Item` yet, but we will soon (adding in `ShareableListItem` from the `Item` side).

joining on `itemId`, but we could also use `url`. is there a preference at this point?
