### PR TITLE
Infra 1169/synthetic skeleton

### DIFF
--- a/.aws/.gitignore
+++ b/.aws/.gitignore
@@ -1,4 +1,7 @@
 .terraform/
-node_modules/
 cdktf.out/
 .gen/
+!src/files/nodejs/node_modules/
+node_modules/*
+!src/files/nodejs/node_modules/synthetic
+src/files/nodejs/node_modules/jmespath

--- a/.aws/package-lock.json
+++ b/.aws/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@pocket-tools/terraform-modules": "4.14.0"
+        "@pocket-tools/terraform-modules": "4.14.0",
+        "jmespath": "0.16.0"
       },
       "devDependencies": {
+        "@pocket-tools/tsconfig": "2.0.1",
         "@types/node": "18.16.3",
         "typescript": "5.0.4"
       }
@@ -472,6 +474,30 @@
       },
       "engines": {
         "node": ">=16.18"
+      }
+    },
+    "node_modules/@pocket-tools/tsconfig": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@pocket-tools/tsconfig/-/tsconfig-2.0.1.tgz",
+      "integrity": "sha512-XZ0A2mLokgfCoIYRovQw3/d+ko7IfkormS/nbETDGk9yXnfBH1UHdjx0zhNAcVuv70Pk9tK2DzhPcy8JUIaCiQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "pkg-up": "4.0.0",
+        "typescript": "4.7.4"
+      }
+    },
+    "node_modules/@pocket-tools/tsconfig/node_modules/typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@sentry/core": {
@@ -2137,6 +2163,14 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3205,6 +3239,91 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkg-up": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-4.0.0.tgz",
+      "integrity": "sha512-N4zdA4sfOe6yCv+ulPCmpnIBQ5I60xfhDr1otdBBhKte9QtEf3bhfrfkW7dTb+IQ0iEx4ZDzas0kc1o5rdWpYg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^6.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-up/node_modules/find-up": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-up/node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-up/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/prettier": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
@@ -3880,6 +3999,18 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yoga-layout-prebuilt": {

--- a/.aws/package.json
+++ b/.aws/package.json
@@ -7,16 +7,16 @@
   "private": true,
   "scripts": {
     "build:dev": "rm -rf dist && NODE_ENV=development npm run synth",
-    "synth": "cdktf synth",
+    "synth": "cp -r node_modules/jmespath/ src/files/nodejs/node_modules/jmespath/ && cdktf synth",
     "compile": "tsc --pretty",
-    "watch": "tsc -w",
-    "test": "echo ok",
     "lint-fix": "eslint --fix \"src/**/*.ts\""
   },
   "dependencies": {
-    "@pocket-tools/terraform-modules": "4.14.0"
+    "@pocket-tools/terraform-modules": "4.14.0",
+    "jmespath": "0.16.0"
   },
   "devDependencies": {
+    "@pocket-tools/tsconfig": "2.0.1",
     "@types/node": "18.16.3",
     "typescript": "5.0.4"
   }

--- a/.aws/src/files/nodejs/node_modules/synthetic/index.ts
+++ b/.aws/src/files/nodejs/node_modules/synthetic/index.ts
@@ -1,0 +1,153 @@
+// adapted from https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries_Samples.html
+// probably this is to be moved into own, small javascript package at some point.
+
+// https://www.npmjs.com/package/@aws-cdk/aws-synthetics
+const synthetics = require('Synthetics');
+const log = require('SyntheticsLogger');
+const syntheticsConfiguration = synthetics.getConfiguration();
+const syntheticsLogHelper = require('SyntheticsLogHelper');
+const jmespath = require('../jmespath/jmespath'); // expected synthetic structure - deps zipped w/synthetic code
+
+const getValidUrl = (url = "") => {
+  var pattern = /^((http|https):\/\/)/;
+
+  if (url === "") {
+    throw new Error(`Error: empty URL envvar`);
+  }
+
+  if (!pattern.test(url)) {
+    // default to https if not present
+    url = "https://" + url;
+  }
+  return url;
+};
+
+const checkUptime = async function () {
+  const url = getValidUrl(process.env.UPTIME_URL || "");
+  const responseCheck = process.env.UPTIME_BODY || "";
+
+  syntheticsConfiguration.disableStepScreenshots();
+  syntheticsConfiguration.setConfig({
+    continueOnStepFailure: true,
+    includeRequestHeaders: true,
+    includeResponseHeaders: true,
+    restrictedHeaders: [],
+    restrictedUrlParameters: [],
+  });
+
+  // makes a puppeteer object for synthetics
+  let page = await synthetics.getPage();
+  await loadUrl(page, url, responseCheck);
+};
+
+const loadUrl = async function (page, url: string, responseCheck: string) {
+  let stepName = "";
+  let domcontentloaded = false;
+
+  try {
+    stepName = new URL(url).hostname;
+  } catch (error) {
+    log.error(`Error parsing url ${url} : ${error}`);
+    throw error;
+  }
+
+  await synthetics.executeStep(stepName, async function () {
+    const sanitizedUrl = syntheticsLogHelper.getSanitizedUrl(url);
+    // https://pptr.dev/api/puppeteer.httpresponse
+    const response = await page.goto(url, {
+      waitUntil: ['domcontentloaded'],
+      timeout: 30000,
+    });
+    if (response) {
+      domcontentloaded = true;
+      const responseText = await response.text();
+      const status = response.status();
+      const statusText = response.statusText();
+
+      if (status < 200 || status > 299) {
+        throw new Error(`Non-2XX response: ${sanitizedUrl} ${status} ${statusText}`);
+      };
+
+      if (responseText !== responseCheck) {
+        throw new Error(`Not expected response. Expected: ${responseCheck} Received: ${responseText}`);
+      };
+
+      log.info(`Response: ${sanitizedUrl}  Status: ${status}  Status Text: ${statusText}`);
+    } else {
+      const logNoResponseString = `No response: ${sanitizedUrl}`;
+      throw new Error(logNoResponseString);
+    };
+  });
+};
+
+const checkQuery = async function () {
+  const endpoint = process.env.GRAPHQL_ENDPOINT || "";
+  const queryJmespath = process.env.GRAPHQL_JMESPATH || "";
+  const query = process.env.GRAPHQL_QUERY || "";
+  const responseCheck = process.env.GRAPHQL_RESPONSE || "";
+
+  syntheticsConfiguration.disableStepScreenshots();
+  syntheticsConfiguration.setConfig({
+    continueOnStepFailure: true,
+    includeRequestHeaders: true,
+    includeResponseHeaders: true,
+    restrictedHeaders: [],
+    restrictedUrlParameters: [],
+  });
+
+  const validateSuccessful = async res => {
+    return new Promise<void>((resolve, reject) => {
+      if (res.statusCode < 200 || res.statusCode > 299) {
+        throw new Error(`${res.statusCode} ${res.statusMessage}`);
+      };
+
+      let responseRaw = '';
+      res.on('data', (d) => {
+        responseRaw += d;
+      });
+
+      res.on('end', () => {
+        const bodyJson = JSON.parse(responseRaw);
+        if (queryJmespath === '') {
+          const response = JSON.stringify(bodyJson);
+          if (response !== responseCheck) {
+            throw new Error(`Not expected response. Received: ${response} Expected: ${responseCheck}`);
+          };
+        } else {
+          const response = jmespath.search(bodyJson, queryJmespath);
+          if (response !== responseCheck) {
+            throw new Error(`Not expected response. Received: ${response} Expected: ${responseCheck}`);
+          };
+        };
+        resolve();
+      });
+    });
+  };
+
+  let requestOptions = {
+    body: query,
+    headers: { "Content-Type": "application/json" },
+    hostname: endpoint,
+    method: 'POST',
+    protocol: 'https:',
+  };
+  requestOptions['headers']['User-Agent'] = [synthetics.getCanaryUserAgentString(), requestOptions['headers']['User-Agent']].join(' ');
+
+  let stepConfig = {
+    includeRequestHeaders: true,
+    includeResponseHeaders: true,
+    includeRequestBody: true,
+    includeResponseBody: true,
+    continueOnHttpStepFailure: true
+  };
+
+  await synthetics.executeHttpStep('Verify GraphQL Query', requestOptions, validateSuccessful, stepConfig);
+};
+
+exports.uptime = async () => {
+  return await checkUptime();
+};
+
+exports.query = async () => {
+  return await checkQuery();
+};

--- a/.aws/src/synthetics.ts
+++ b/.aws/src/synthetics.ts
@@ -1,0 +1,272 @@
+// to be moved into own terraform module, preferably HCL that is then consumed by CDKTF in the app instatiation.
+import { config } from './config';
+import * as path from 'path';
+import { CloudwatchMetricAlarm } from '@cdktf/provider-aws/lib/cloudwatch-metric-alarm';
+import { DataArchiveFile } from '@cdktf/provider-archive/lib/data-archive-file';
+import { DataAwsIamPolicyDocument } from '@cdktf/provider-aws/lib/data-aws-iam-policy-document';
+import { IamPolicy } from '@cdktf/provider-aws/lib/iam-policy';
+import { IamRole } from '@cdktf/provider-aws/lib/iam-role';
+import { IamRolePolicyAttachment } from '@cdktf/provider-aws/lib/iam-role-policy-attachment';
+import { S3Bucket } from '@cdktf/provider-aws/lib/s3-bucket';
+import { SyntheticsCanary } from '@cdktf/provider-aws/lib/synthetics-canary';
+import { AssetType, TerraformAsset } from 'cdktf';
+import { Construct } from 'constructs';
+
+interface syntheticQueryConfig {
+  data?: string;
+  endpoint?: string;
+  jmespath?: string;
+  response?: string;
+}
+
+interface syntheticUptimeConfig {
+  response?: string;
+  url?: string;
+}
+
+interface syntheticCheckConfigs {
+  query: syntheticQueryConfig[];
+  securityGroupIds?: string[];
+  subnetIds?: string[];
+  uptime: syntheticUptimeConfig[];
+}
+
+/**
+ * Create additional monitoring
+ * @param app
+ * @param provider
+ */
+export class APIMonitoring extends Construct {
+  public readonly scope: Construct;
+  public readonly name: string;
+
+  constructor(scope: Construct, name: string) {
+    super(scope, name);
+  }
+
+  createSyntheticChecks(
+    checkConfigs: syntheticCheckConfigs,
+    snsCriticalAlarmTopicARN = ''
+  ) {
+    const syntheticArtifactsS3 = new S3Bucket(
+      this,
+      'synthetic_check_artifacts',
+      {
+        bucket: `pocket-${config.prefix.toLowerCase()}-synthetic-checks`,
+        lifecycleRule: [
+          {
+            enabled: true,
+            expiration: {
+              days: 30,
+            },
+            id: '30-day-retention',
+          },
+        ],
+      }
+    );
+
+    const syntheticCode = new TerraformAsset(this, 'synthetic_check_asset', {
+      path: path.resolve(`${__dirname}`, 'files'),
+      type: AssetType.DIRECTORY,
+    });
+
+    const syntheticZipFile = new DataArchiveFile(this, 'synthetic_check_zip', {
+      outputPath: `generated-archives/synthetic-${syntheticCode.assetHash}.zip`,
+      sourceDir: syntheticCode.path,
+      type: 'zip',
+    });
+
+    // behind the scenes, Cloudwatch Synthetics are AWS-managed Lambdas
+    const dataSyntheticAssume = new DataAwsIamPolicyDocument(
+      this,
+      'synthetic_check_assume',
+      {
+        version: '2012-10-17',
+        statement: [
+          {
+            effect: 'Allow',
+            actions: ['sts:AssumeRole'],
+
+            principals: [
+              {
+                identifiers: ['lambda.amazonaws.com'],
+                type: 'Service',
+              },
+            ],
+          },
+        ],
+      }
+    );
+
+    const syntheticRole = new IamRole(this, 'synthetic_check_role', {
+      name: `pocket-${config.prefix.toLowerCase()}-synthetic-check`,
+
+      assumeRolePolicy: dataSyntheticAssume.json,
+      tags: config.tags,
+    });
+
+    // puts artifacts into s3, stores logs, pushes metrics to Cloudwatch
+    // also create networkinterfaces if synthetic check in VPC
+    const dataSyntheticAccess = new DataAwsIamPolicyDocument(
+      this,
+      'synthetic_check_access',
+      {
+        version: '2012-10-17',
+        statement: [
+          {
+            effect: 'Allow',
+            actions: [
+              'logs:CreateLogGroup',
+              'logs:CreateLogStream',
+              'logs:PutLogEvents',
+            ],
+            resources: ['*'],
+          },
+          {
+            actions: ['s3:PutObject', 's3:GetObject'],
+            resources: [`${syntheticArtifactsS3.arn}/*`],
+          },
+          {
+            actions: ['s3:GetBucketLocation'],
+            resources: [syntheticArtifactsS3.arn],
+          },
+          {
+            actions: ['s3:ListAllMyBuckets'],
+            resources: ['*'],
+          },
+          {
+            actions: ['cloudwatch:PutMetricData'],
+            resources: ['*'],
+            condition: [
+              {
+                test: 'StringEquals',
+                values: ['CloudWatchSynthetics'],
+                variable: 'cloudwatch:namespace',
+              },
+            ],
+          },
+          {
+            actions: [
+              'ec2:AttachNetworkInterface',
+              'ec2:CreateNetworkInterface',
+              'ec2:DeleteNetworkInterface',
+              'ec2:DescribeNetworkInterfaces',
+            ],
+            resources: ['*'],
+          },
+        ],
+      }
+    );
+
+    const syntheticAccessPolicy = new IamPolicy(
+      this,
+      'synthetic_check_access_policy',
+      {
+        name: `pocket-${config.prefix.toLowerCase()}-synthetic-check-access`,
+        policy: dataSyntheticAccess.json,
+      }
+    );
+
+    new IamRolePolicyAttachment(this, 'synthetic_check_access_attach', {
+      role: syntheticRole.id,
+      policyArn: syntheticAccessPolicy.arn,
+    });
+
+    for (const uptimeConfig of checkConfigs.uptime) {
+      const count = checkConfigs.uptime.indexOf(uptimeConfig);
+      const check = new SyntheticsCanary(this, 'synthetic_check_uptime', {
+        name: `${config.shortName.toLowerCase()}-${config.environment.toLowerCase()}-uptime-${count}`, // limit of 21 characters
+        artifactS3Location: `s3://${syntheticArtifactsS3.bucket}/`,
+        executionRoleArn: syntheticRole.arn,
+        handler: 'synthetic.uptime',
+        runConfig: {
+          environmentVariables: {
+            UPTIME_BODY: uptimeConfig.response,
+            UPTIME_URL: uptimeConfig.url,
+          },
+          timeoutInSeconds: 180, // 3 minute timeout
+        },
+        runtimeVersion: 'syn-nodejs-puppeteer-4.0',
+        schedule: {
+          expression: 'rate(5 minutes)', // run every 5 minutes
+        },
+        startCanary: true,
+        vpcConfig: {
+          subnetIds: checkConfigs.subnetIds,
+          securityGroupIds: checkConfigs.securityGroupIds,
+        },
+        zipFile: syntheticZipFile.outputPath,
+      });
+
+      new CloudwatchMetricAlarm(this, 'synthetic_check_alarm_uptime', {
+        alarmDescription: `Alert when ${check.name} canary success percentage has decreased below 66% in the last 15 minutes`,
+        alarmName: check.name,
+        comparisonOperator: 'LessThanThreshold',
+        dimensions: {
+          CanaryName: check.name,
+        },
+        evaluationPeriods: 3,
+        metricName: 'SuccessPercent',
+        namespace: 'CloudWatchSynthetics',
+        period: 300, // 15 minutes
+        statistic: 'Average',
+        threshold: 66,
+        treatMissingData: 'breaching',
+
+        alarmActions: [snsCriticalAlarmTopicARN],
+        insufficientDataActions: [],
+        okActions: [snsCriticalAlarmTopicARN],
+      });
+    }
+
+    for (const queryConfig of checkConfigs.query) {
+      const count = checkConfigs.query.indexOf(queryConfig);
+      const check = new SyntheticsCanary(this, 'synthetic_check_query', {
+        name: `${config.shortName.toLowerCase()}-${config.environment.toLowerCase()}-query-${count}`, // limit of 21 characters
+        artifactS3Location: `s3://${syntheticArtifactsS3.bucket}/`,
+        executionRoleArn: syntheticRole.arn,
+        handler: 'synthetic.query',
+        runConfig: {
+          environmentVariables: {
+            GRAPHQL_ENDPOINT: queryConfig.endpoint,
+            GRAPHQL_JMESPATH: queryConfig.jmespath,
+            GRAPHQL_QUERY: queryConfig.data,
+            GRAPHQL_RESPONSE: queryConfig.response,
+          },
+          timeoutInSeconds: 180, // 3 minute timeout
+        },
+        runtimeVersion: 'syn-nodejs-puppeteer-4.0',
+        schedule: {
+          expression: 'rate(5 minutes)', // run every 5 minutes
+        },
+        startCanary: true,
+        vpcConfig: {
+          subnetIds: checkConfigs.subnetIds,
+          securityGroupIds: checkConfigs.securityGroupIds,
+        },
+        zipFile: syntheticZipFile.outputPath,
+      });
+
+      new CloudwatchMetricAlarm(this, 'synthetic_check_alarm_query', {
+        alarmDescription: `Alert when ${check.name} canary success percentage has decreased below 66% in the last 15 minutes`,
+        alarmName: check.name,
+
+        comparisonOperator: 'LessThanThreshold',
+        dimensions: {
+          CanaryName: check.name,
+        },
+        evaluationPeriods: 3,
+        metricName: 'SuccessPercent',
+        namespace: 'CloudWatchSynthetics',
+        period: 300, // 15 minutes
+        statistic: 'Average',
+        threshold: 66,
+        treatMissingData: 'breaching',
+
+        alarmActions: [snsCriticalAlarmTopicARN],
+        insufficientDataActions: [],
+        okActions: [snsCriticalAlarmTopicARN],
+      });
+    }
+  }
+}

--- a/.aws/tsconfig.json
+++ b/.aws/tsconfig.json
@@ -1,16 +1,18 @@
 {
+  "extends": "@pocket-tools/tsconfig",
   "compilerOptions": {
-    "target": "es2020",
-    "module": "commonjs",
-    "lib": ["dom"],
+    "allowJs": true,
     "outDir": "dist",
-    "removeComments": true,
-    "esModuleInterop": true,
-    "noEmitOnError": true,
-    "sourceMap": true,
-    "inlineSources": true,
-    "sourceRoot": "/"
+    "rootDir": "src",
+    "target": "es2020",
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "**/*.ts",
+    "src/files/nodejs/node_modules/jmespath/*.js",
+    "src/files/nodejs/node_modules/synthetic/*.ts",
+  ],
+  "exclude": [
+    "dist/",
+    "node_modules/",
+  ]
 }


### PR DESCRIPTION
## Goal

Synthetic Alerts skeleton. Has some sane defaults.

Sets up synthetic alert (in vpc) for uptime checks (e.g. http endpoint on get returns 2xx) & "query" checks (e.g. http post on graphql endpoint with graphql sent & jmespath + expected response to validate response).

Removes old alerts from setup (default being load balance 5xx checks, which have failed us in the past).

Long term, the idea is to have this synthetic setup as generic as possible for uptime & graphql checks, then spin up needed synthetics via that config map structure (which just maps to environment variables for the synthetic checks).

## Todos

Shouldn't block this PR going through, but immediate next steps

- [ ] Get @wtfluckey & @jpetto plus others in shareable lists work to add to / validate endpoints we should check
- [ ] link these checks (once in dev & prod) to shareable lists service doc & SLIs where relevant
- [ ] move the synthetic check javascript code to its own repo so it can be deployed to s3 & reused across many synthetic check instantiations (and avoid the insanity of cdktf ts > tf json > tf resource requiring js > ts/js > zip bundling process
- [ ] move the synthetic check terraform to a module for ease of reuse
- [ ] update alerting docs with examples & further details on using this setup
