### PR TITLE
chore(shareableListPublic): add listItemNoteVisibility to query

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -98,6 +98,10 @@ type ShareableListPublic implements ShareableListInterface
   Pocket Saves that have been added to this list by the Pocket user.
   """
   listItems: [ShareableListItem!]! @cacheControl(maxAge: 60, scope: PUBLIC)
+  """
+  The visibility of notes added to list items for this list.
+  """
+  listItemNoteVisibility: ShareableListVisibility!
 }
 
 """

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -169,6 +169,10 @@ interface ShareableListInterface {
   Pocket Saves that have been added to this list by the Pocket user.
   """
   listItems: [ShareableListItem!]!
+  """
+  The visibility of notes added to list items for this list.
+  """
+  listItemNoteVisibility: ShareableListVisibility!
 }
 
 """

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -530,7 +530,7 @@ describe('public queries: ShareableList', () => {
         2
       );
 
-      // default PRIVATE listItemNoteVisibility
+      // listItemNoteVisibility is PUBLIC in this scenario
       expect(
         result.body.data.shareableListPublic.listItemNoteVisibility
       ).to.equal(Visibility.PUBLIC);

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -413,6 +413,9 @@ describe('public queries: ShareableList', () => {
 
       // Empty list items array
       expect(list.listItems).to.have.lengthOf(0);
+
+      // default PRIVATE listItemNoteVisibility
+      expect(list.listItemNoteVisibility).to.equal(Visibility.PRIVATE);
     });
 
     it('should return a list with sorted list items', async () => {
@@ -526,6 +529,11 @@ describe('public queries: ShareableList', () => {
       expect(result.body.data.shareableListPublic.listItems).to.have.lengthOf(
         2
       );
+
+      // default PRIVATE listItemNoteVisibility
+      expect(
+        result.body.data.shareableListPublic.listItemNoteVisibility
+      ).to.equal(Visibility.PUBLIC);
 
       // Let's run through the visible props of each item
       // to make sure they're all there

--- a/src/shared/fragments.gql.ts
+++ b/src/shared/fragments.gql.ts
@@ -69,6 +69,7 @@ export const ShareableListPublicQueryProps = gql`
     listItems {
       ...ShareableListItemPublicProps
     }
+    listItemNoteVisibility
   }
   ${ShareableListItemPublicProps}
 `;


### PR DESCRIPTION
## Goal

add listItemNoteVisibility to `shareableListPublic` query

## Tickets

- https://getpocket.atlassian.net/browse/OSL-503

## Implementation Decisions

even though they are now equal, kept the `ShareableListPublicProps` and `ShareableListPublicQueryProps` fragments separate, as these may well diverge in the near future.