### PR TITLE
refactor(metadata): list item metadata now owned by parser service

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -130,12 +130,7 @@ input CreateShareableListItemInput {
   listExternalId: ID!
   itemId: ID!
   url: Url!
-  title: String
-  excerpt: String
   note: String @constraint(maxLength: 300)
-  imageUrl: Url
-  publisher: String
-  authors: String
   sortOrder: Int!
 }
 
@@ -145,12 +140,7 @@ Input data for creating a Shareable List Item during Shareable List creation.
 input CreateShareableListItemWithList {
   itemId: ID!
   url: Url!
-  title: String
-  excerpt: String
   note: String @constraint(maxLength: 300)
-  imageUrl: Url
-  publisher: String
-  authors: String
   sortOrder: Int!
 }
 

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -86,32 +86,9 @@ type ShareableListItem {
   """
   url: Url!
   """
-  The title of the story. Supplied by the Parser.
-  May not be available for URLs that cannot be resolved.
-  Not editable by the Pocket user, as are all the other
-  Parser-supplied story properties below.
-  """
-  title: String
-  """
-  The excerpt of the story. Supplied by the Parser.
-  """
-  excerpt: String
-  """
   User generated note to accompany this list item.
   """
   note: String
-  """
-  The URL of the thumbnail image illustrating the story. Supplied by the Parser.
-  """
-  imageUrl: Url
-  """
-  The name of the publisher for this story. Supplied by the Parser.
-  """
-  publisher: String
-  """
-  A comma-separated list of story authors. Supplied by the Parser.
-  """
-  authors: String
   """
   The custom sort order of stories within a list. Defaults to 1.
   """

--- a/src/admin/resolvers/queries/ShareableList.integration.ts
+++ b/src/admin/resolvers/queries/ShareableList.integration.ts
@@ -142,12 +142,7 @@ describe('admin queries: ShareableList', () => {
       expect(listItem.externalId).not.to.be.empty;
       expect(listItem.itemId).to.equal('3834701731');
       expect(listItem.url).to.equal(shareableListItem.url);
-      expect(listItem.title).to.equal(shareableListItem.title);
-      expect(listItem.excerpt).to.equal(shareableListItem.excerpt);
       expect(listItem.note).to.equal(shareableListItem.note);
-      expect(listItem.imageUrl).to.equal(shareableListItem.imageUrl);
-      expect(listItem.publisher).to.equal(shareableListItem.publisher);
-      expect(listItem.authors).to.equal(shareableListItem.authors);
       expect(listItem.sortOrder).to.equal(1);
       expect(listItem.createdAt).not.to.be.empty;
       expect(listItem.updatedAt).not.to.be.empty;

--- a/src/database/mutations/ShareableListItem.ts
+++ b/src/database/mutations/ShareableListItem.ts
@@ -65,12 +65,7 @@ export async function createShareableListItem(
     // coerce itemId to a number to conform to db schema
     itemId: parseInt(data.itemId),
     url: data.url,
-    title: data.title ?? undefined,
-    excerpt: data.excerpt ?? undefined,
     note: data.note ?? undefined,
-    imageUrl: data.imageUrl ?? undefined,
-    publisher: data.publisher ?? undefined,
-    authors: data.authors ?? undefined,
     sortOrder: data.sortOrder,
     listId: list.id,
   };

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -38,12 +38,7 @@ export const shareableListItemSelectFields =
     externalId: true,
     itemId: true,
     url: true,
-    title: true,
-    excerpt: true,
     note: true,
-    imageUrl: true,
-    publisher: true,
-    authors: true,
     sortOrder: true,
     createdAt: true,
     updatedAt: true,
@@ -132,12 +127,7 @@ export type CreateShareableListItemInput = {
   listExternalId: string;
   itemId: string;
   url: string;
-  title?: string;
-  excerpt?: string;
   note?: string;
-  imageUrl?: string;
-  publisher?: string;
-  authors?: string;
   sortOrder: number;
 };
 

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -206,11 +206,6 @@ describe('public mutations: ShareableList', () => {
       const listItemData = {
         itemId: '378asdf9538749', // invalid!
         url: 'https://www.test.com/this-is-a-story',
-        title: 'A story is a story',
-        excerpt: '<blink>The best story ever told</blink>',
-        imageUrl: 'https://www.test.com/thumbnail.jpg',
-        publisher: 'The London Times',
-        authors: 'Charles Dickens, Mark Twain',
         sortOrder: 10,
       };
 
@@ -240,11 +235,6 @@ describe('public mutations: ShareableList', () => {
       const listItemData = {
         itemId: '3789538749',
         url: 'https://www.test.com/this-is-a-story',
-        title: 'A story is a story',
-        excerpt: '<blink>The best story ever told</blink>',
-        imageUrl: 'https://www.test.com/thumbnail.jpg',
-        publisher: 'The London Times',
-        authors: 'Charles Dickens, Mark Twain',
         sortOrder: 10,
       };
 
@@ -269,14 +259,9 @@ describe('public mutations: ShareableList', () => {
 
       const listItem = list.listItems[0];
 
-      expect(listItem.title).to.equal(listItemData.title);
       expect(listItem.url).to.equal(listItemData.url);
       expect(listItem.itemId).to.equal(listItemData.itemId);
       expect(listItem.item.itemId).to.equal(listItemData.itemId);
-      expect(listItem.excerpt).to.equal(listItemData.excerpt);
-      expect(listItem.imageUrl).to.equal(listItemData.imageUrl);
-      expect(listItem.publisher).to.equal(listItemData.publisher);
-      expect(listItem.authors).to.equal(listItemData.authors);
       expect(listItem.sortOrder).to.equal(listItemData.sortOrder);
     });
 

--- a/src/public/resolvers/mutations/ShareableListItem.integration.ts
+++ b/src/public/resolvers/mutations/ShareableListItem.integration.ts
@@ -156,7 +156,6 @@ describe('public mutations: ShareableListItem', () => {
         listExternalId: pilotList.externalId,
         itemId: '1',
         url: 'https://www.test.com/this-is-a-story',
-        title: 'This Story Is Trying to Sneak In',
         sortOrder: 20,
       };
 
@@ -181,11 +180,6 @@ describe('public mutations: ShareableListItem', () => {
         listExternalId: list.externalId,
         itemId: '383asdf4701731',
         url: 'https://www.test.com/this-is-a-story',
-        title: 'A story is a story',
-        excerpt: '<blink>The best story ever told</blink>',
-        imageUrl: 'https://www.test.com/thumbnail.jpg',
-        publisher: 'The London Times',
-        authors: 'Charles Dickens, Mark Twain',
         sortOrder: 10,
       };
 
@@ -209,12 +203,7 @@ describe('public mutations: ShareableListItem', () => {
         listExternalId: list.externalId,
         itemId: '3834701731',
         url: 'https://www.test.com/this-is-a-story',
-        title: 'A story is a story',
-        excerpt: '<blink>The best story ever told</blink>',
         note: faker.random.alpha(LIST_ITEM_NOTE_MAX_CHARS + 1),
-        imageUrl: 'https://www.test.com/thumbnail.jpg',
-        publisher: 'The London Times',
-        authors: 'Charles Dickens, Mark Twain',
         sortOrder: 10,
       };
 
@@ -237,11 +226,6 @@ describe('public mutations: ShareableListItem', () => {
         listExternalId: list.externalId,
         itemId: '3834701731',
         url: 'https://www.test.com/this-is-a-story',
-        title: 'A story is a story',
-        excerpt: '<blink>The best story ever told</blink>',
-        imageUrl: 'https://www.test.com/thumbnail.jpg',
-        publisher: 'The London Times',
-        authors: 'Charles Dickens, Mark Twain',
         sortOrder: 10,
       };
 
@@ -265,14 +249,7 @@ describe('public mutations: ShareableListItem', () => {
       expect(listItem.itemId).to.equal(data.itemId);
       expect(listItem.item.itemId).to.equal(data.itemId);
       expect(listItem.url).to.equal(data.url);
-      expect(listItem.title).to.equal(data.title);
-      expect(listItem.excerpt).to.equal(
-        '&lt;blink&gt;The best story ever told&lt;/blink&gt;'
-      );
       expect(listItem.note).to.be.null;
-      expect(listItem.imageUrl).to.equal(data.imageUrl);
-      expect(listItem.publisher).to.equal(data.publisher);
-      expect(listItem.authors).to.equal(data.authors);
       expect(listItem.sortOrder).to.equal(data.sortOrder);
       expect(listItem.createdAt).not.to.be.empty;
       expect(listItem.updatedAt).not.to.be.empty;
@@ -283,12 +260,7 @@ describe('public mutations: ShareableListItem', () => {
         listExternalId: list.externalId,
         itemId: '3834701731',
         url: 'https://www.test.com/this-is-a-story',
-        title: 'A story is a story',
-        excerpt: '<blink>The best story ever told</blink>',
         note: '<div>here is what <strong>i</strong> think about this article...</div>',
-        imageUrl: 'https://www.test.com/thumbnail.jpg',
-        publisher: 'The London Times',
-        authors: 'Charles Dickens, Mark Twain',
         sortOrder: 10,
       };
 
@@ -316,16 +288,9 @@ describe('public mutations: ShareableListItem', () => {
       expect(listItem.itemId).to.equal(data.itemId);
       expect(listItem.item.itemId).to.equal(data.itemId);
       expect(listItem.url).to.equal(data.url);
-      expect(listItem.title).to.equal(data.title);
-      expect(listItem.excerpt).to.equal(
-        '&lt;blink&gt;The best story ever told&lt;/blink&gt;'
-      );
       expect(listItem.note).to.equal(
         '&lt;div&gt;here is what &lt;strong&gt;i&lt;/strong&gt; think about this article...&lt;/div&gt;'
       );
-      expect(listItem.imageUrl).to.equal(data.imageUrl);
-      expect(listItem.publisher).to.equal(data.publisher);
-      expect(listItem.authors).to.equal(data.authors);
       expect(listItem.sortOrder).to.equal(data.sortOrder);
       expect(listItem.createdAt).not.to.be.empty;
       expect(listItem.updatedAt).not.to.be.empty;
@@ -379,12 +344,7 @@ describe('public mutations: ShareableListItem', () => {
         listExternalId: list.externalId,
         itemId: '3789538749',
         url: 'https://www.test.com/another-duplicate-url',
-        title: 'A story is a story',
-        excerpt: 'The best story ever told',
         note: 'here is what i think about this article...',
-        imageUrl: 'https://www.test.com/thumbnail.jpg',
-        publisher: 'The Hogwarts Express',
-        authors: 'Charles Dickens, Mark Twain',
         sortOrder: 5,
       };
 
@@ -409,12 +369,7 @@ describe('public mutations: ShareableListItem', () => {
       expect(listItem.itemId).to.equal(data.itemId);
       expect(listItem.item.itemId).to.equal(data.itemId);
       expect(listItem.url).to.equal(data.url);
-      expect(listItem.title).to.equal(data.title);
-      expect(listItem.excerpt).to.equal(data.excerpt);
       expect(listItem.note).to.equal(data.note);
-      expect(listItem.imageUrl).to.equal(data.imageUrl);
-      expect(listItem.publisher).to.equal(data.publisher);
-      expect(listItem.authors).to.equal(data.authors);
       expect(listItem.sortOrder).to.equal(data.sortOrder);
       expect(listItem.createdAt).not.to.be.empty;
       expect(listItem.updatedAt).not.to.be.empty;
@@ -1023,8 +978,8 @@ describe('public mutations: ShareableListItem', () => {
       // This mutation should not be cached, expect headers.cache-control = no-store
       expect(result.headers['cache-control']).to.equal('no-store');
       expect(result.body.data.deleteShareableListItem).to.exist;
-      expect(result.body.data.deleteShareableListItem.title).to.equal(
-        listItem1.title
+      expect(result.body.data.deleteShareableListItem.url).to.equal(
+        listItem1.url
       );
       // Assert that the item is not present in the db anymore
       // by trying to delete the same item

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -227,12 +227,7 @@ describe('public queries: ShareableList', () => {
         expect(listItem.itemId).not.to.be.empty;
         expect(listItem.item.itemId).not.to.be.empty;
         expect(listItem.url).not.to.be.empty;
-        expect(listItem.title).not.to.be.empty;
-        expect(listItem.excerpt).not.to.be.empty;
         expect(listItem.note).not.to.be.empty;
-        expect(listItem.imageUrl).not.to.be.empty;
-        expect(listItem.publisher).not.to.be.empty;
-        expect(listItem.authors).not.to.be.empty;
         expect(listItem.sortOrder).to.be.a('number');
         expect(listItem.createdAt).not.to.be.empty;
         expect(listItem.updatedAt).not.to.be.empty;
@@ -467,13 +462,8 @@ describe('public queries: ShareableList', () => {
         expect(listItem.itemId).not.to.be.empty;
         expect(listItem.item.itemId).not.to.be.empty;
         expect(listItem.url).not.to.be.empty;
-        expect(listItem.title).not.to.be.empty;
-        expect(listItem.excerpt).not.to.be.empty;
         // note should be empty because the visibility on the list is PRIVATE
         expect(listItem.note).to.be.null;
-        expect(listItem.imageUrl).not.to.be.empty;
-        expect(listItem.publisher).not.to.be.empty;
-        expect(listItem.authors).not.to.be.empty;
         expect(listItem.sortOrder).to.be.a('number');
         expect(listItem.createdAt).not.to.be.empty;
         expect(listItem.updatedAt).not.to.be.empty;
@@ -541,13 +531,8 @@ describe('public queries: ShareableList', () => {
         expect(listItem.itemId).not.to.be.empty;
         expect(listItem.item.itemId).not.to.be.empty;
         expect(listItem.url).not.to.be.empty;
-        expect(listItem.title).not.to.be.empty;
-        expect(listItem.excerpt).not.to.be.empty;
         // note should not be empty because the visibility on the list is PUBLIC
         expect(listItem.note).not.to.be.empty;
-        expect(listItem.imageUrl).not.to.be.empty;
-        expect(listItem.publisher).not.to.be.empty;
-        expect(listItem.authors).not.to.be.empty;
         expect(listItem.sortOrder).to.be.a('number');
         expect(listItem.createdAt).not.to.be.empty;
         expect(listItem.updatedAt).not.to.be.empty;
@@ -695,11 +680,6 @@ describe('public queries: ShareableList', () => {
         expect(listItem.itemId).not.to.be.empty;
         expect(listItem.item.itemId).not.to.be.empty;
         expect(listItem.url).not.to.be.empty;
-        expect(listItem.title).not.to.be.empty;
-        expect(listItem.excerpt).not.to.be.empty;
-        expect(listItem.imageUrl).not.to.be.empty;
-        expect(listItem.publisher).not.to.be.empty;
-        expect(listItem.authors).not.to.be.empty;
         expect(listItem.sortOrder).to.be.a('number');
         expect(listItem.createdAt).not.to.be.empty;
         expect(listItem.updatedAt).not.to.be.empty;
@@ -717,12 +697,7 @@ describe('public queries: ShareableList', () => {
         expect(listItem.itemId).not.to.be.empty;
         expect(listItem.item.itemId).not.to.be.empty;
         expect(listItem.url).not.to.be.empty;
-        expect(listItem.title).not.to.be.empty;
-        expect(listItem.excerpt).not.to.be.empty;
         expect(listItem.note).not.to.be.empty;
-        expect(listItem.imageUrl).not.to.be.empty;
-        expect(listItem.publisher).not.to.be.empty;
-        expect(listItem.authors).not.to.be.empty;
         expect(listItem.sortOrder).to.be.a('number');
         expect(listItem.createdAt).not.to.be.empty;
         expect(listItem.updatedAt).not.to.be.empty;

--- a/src/public/resolvers/utils.spec.ts
+++ b/src/public/resolvers/utils.spec.ts
@@ -68,19 +68,14 @@ describe('utility functions', () => {
       const input: CreateShareableListItemInput = {
         listExternalId: '123-abc',
         itemId: '456789',
-        url: 'https://www.test.com/story',
-        title: 'This is a test title',
-        excerpt: 'An excerpt sounds like a good thing to have',
-        imageUrl: 'https://www.test.com/<script>alert("hello world");</script>',
-        publisher: 'House of Random Penguins',
-        authors: 'Charles Dickens',
+        url: 'https://www.test.com/<script>alert("hello world");</script>',
         sortOrder: 10,
       };
 
       const safeInput = sanitizeMutationInput(input);
 
       // dodgy strings are still escaped
-      expect(safeInput.imageUrl).to.equal(
+      expect(safeInput.url).to.equal(
         'https://www.test.com/&lt;script&gt;alert("hello world");&lt;/script&gt;'
       );
 

--- a/src/shared/fragments.gql.ts
+++ b/src/shared/fragments.gql.ts
@@ -12,12 +12,7 @@ export const ShareableListItemPublicProps = gql`
       itemId
     }
     url
-    title
-    excerpt
     note
-    imageUrl
-    publisher
-    authors
     sortOrder
     createdAt
     updatedAt

--- a/src/snowplow/events.spec.ts
+++ b/src/snowplow/events.spec.ts
@@ -45,12 +45,7 @@ describe('Snowplow event helpers', () => {
     externalId: faker.datatype.uuid(),
     itemId: BigInt(98765),
     url: `${faker.internet.url()}/${faker.lorem.slug(5)}`,
-    title: faker.random.words(5),
-    excerpt: faker.lorem.sentences(2),
     note: faker.lorem.sentences(1),
-    imageUrl: faker.image.cats(),
-    publisher: faker.company.name(),
-    authors: `${faker.name.fullName()},${faker.name.fullName()}`,
     sortOrder: faker.datatype.number(),
     createdAt: new Date('2023-01-01 10:10:10'),
     updatedAt: new Date('2023-01-01 10:10:10'),
@@ -340,18 +335,6 @@ describe('Snowplow event helpers', () => {
     );
     // url-> given_url
     expect(payload.shareableListItem.given_url).to.equal(shareableListItem.url);
-    // imageUrl-> image_url
-    expect(payload.shareableListItem.image_url).to.equal(
-      shareableListItem.imageUrl
-    );
-    // authors string getting mapped to array of strings
-    expect(JSON.stringify(payload.shareableListItem.authors)).to.equal(
-      JSON.stringify(shareableListItem.authors.split(','))
-    );
-    // publisher
-    expect(payload.shareableListItem.publisher).to.equal(
-      shareableListItem.publisher
-    );
     // note
     expect(payload.shareableListItem.note).to.equal(shareableListItem.note);
     // sortOrder -> sort_order

--- a/src/snowplow/events.ts
+++ b/src/snowplow/events.ts
@@ -76,17 +76,6 @@ function transformAPIShareableListItemToSnowplowShareableListItem(
     shareable_list_item_external_id: externalId,
     shareable_list_external_id: listExternalId,
     given_url: shareableListItem.url,
-    title: shareableListItem.title ? shareableListItem.title : undefined,
-    excerpt: shareableListItem.excerpt ? shareableListItem.excerpt : undefined,
-    image_url: shareableListItem.imageUrl
-      ? shareableListItem.imageUrl
-      : undefined,
-    authors: shareableListItem.authors
-      ? shareableListItem.authors.split(',')
-      : undefined,
-    publisher: shareableListItem.publisher
-      ? shareableListItem.publisher
-      : undefined,
     note: shareableListItem.note ? shareableListItem.note : undefined,
     sort_order: shareableListItem.sortOrder,
     created_at: Math.floor(shareableListItem.createdAt.getTime() / 1000),

--- a/src/test/helpers/createShareableListItemHelper.ts
+++ b/src/test/helpers/createShareableListItemHelper.ts
@@ -6,12 +6,7 @@ interface ListItemHelperInput {
   list: List;
   itemId?: number;
   url?: string;
-  title?: string;
-  excerpt?: string;
   note?: string;
-  imageUrl?: string;
-  publisher?: string;
-  authors?: string;
   sortOrder?: number;
 }
 
@@ -30,13 +25,8 @@ export async function createShareableListItemHelper(
     listId: data.list.id,
     itemId: data.itemId ?? faker.datatype.number(),
     url: data.url ?? `${faker.internet.url()}/${faker.lorem.slug(5)}`,
-    title: data.title ?? faker.random.words(5),
-    excerpt: data.excerpt ?? faker.lorem.sentences(2),
     // if `null` is passed in, do not add a note to the list item
     note: data.note === undefined ? faker.lorem.sentences(2) : data.note,
-    imageUrl: data.imageUrl ?? faker.image.cats(),
-    publisher: data.publisher ?? faker.company.name(),
-    authors: data.authors ?? faker.name.fullName(),
     // allow sortOrder to fall back to db default if no specific order given
     sortOrder: data.sortOrder ?? undefined,
   };


### PR DESCRIPTION
## Goal

remove all duplicated list item metadata that is now owned by parser service.

- remove references to direct metadata EXCEPT db & snowplow

## Tickets

- https://getpocket.atlassian.net/browse/OSL-493