### PR TITLE
OSL-510: adding an admin shareable list item type

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -63,7 +63,7 @@ type ShareableListComplete implements ShareableListInterface {
   """
   Pocket Saves that have been added to this list by the Pocket user.
   """
-  listItems: [ShareableListItem!]!
+  listItems: [ShareableListItemAdmin!]!
   """
   The visibility of notes added to list items for this list.
   """

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -21,7 +21,65 @@ enum ShareableListModerationReason {
   PHISHING
 }
 
-type ShareableListComplete implements ShareableListInterface {
+"""
+A Pocket Save (story) that has been added to a Shareable List. This is the admin version which
+does not include the Parser Item.
+"""
+type ShareableListItemAdmin {
+  """
+  A unique string identifier in UUID format.
+  """
+  externalId: ID!
+  """
+  The Parser Item ID.
+  """
+  itemId: ID!
+  """
+  The URL of the story saved to a list.
+  """
+  url: Url!
+  """
+  The title of the story. Supplied by the Parser.
+  May not be available for URLs that cannot be resolved.
+  Not editable by the Pocket user, as are all the other
+  Parser-supplied story properties below.
+  """
+  title: String
+  """
+  The excerpt of the story. Supplied by the Parser.
+  """
+  excerpt: String
+  """
+  User generated note to accompany this list item.
+  """
+  note: String
+  """
+  The URL of the thumbnail image illustrating the story. Supplied by the Parser.
+  """
+  imageUrl: Url
+  """
+  The name of the publisher for this story. Supplied by the Parser.
+  """
+  publisher: String
+  """
+  A comma-separated list of story authors. Supplied by the Parser.
+  """
+  authors: String
+  """
+  The custom sort order of stories within a list. Defaults to 1.
+  """
+  sortOrder: Int!
+  """
+  The timestamp of when this story was added to the list by its owner.
+  """
+  createdAt: ISOString!
+  """
+  The timestamp of when the story was last updated. Not used for the MVP.
+  """
+  updatedAt: ISOString!
+}
+
+type ShareableListComplete {
   """
   A unique string identifier in UUID format.
   """

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -1,7 +1,7 @@
 """
 A user-created list of Pocket saves that can be shared publicly.
 """
-type ShareableList implements ShareableListInterface {
+type ShareableList {
   """
   A unique string identifier in UUID format.
   """
@@ -54,8 +54,7 @@ type ShareableList implements ShareableListInterface {
 A list that has been already shared publicly.
 This type is needed as it needs to be cached.
 """
-type ShareableListPublic implements ShareableListInterface
-  @cacheControl(maxAge: 60, scope: PUBLIC) {
+type ShareableListPublic @cacheControl(maxAge: 60, scope: PUBLIC) {
   """
   A unique string identifier in UUID format.
   """

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -23,11 +23,6 @@ A URL to a web page or image.
 scalar Url
 
 """
-An abstract GraphQL type which returns a public or admin ShareableListItem.
-"""
-union ShareableListItemUnion = ShareableListItem | ShareableListItemAdmin
-
-"""
 The visibility levels used (e.g. list, list item note) in the Shareable List API. Defaults to PRIVATE - visible only to its owner.
 """
 enum ShareableListVisibility {
@@ -129,113 +124,6 @@ type ShareableListItem {
   The timestamp of when the story was last updated. Not used for the MVP.
   """
   updatedAt: ISOString!
-}
-
-"""
-A Pocket Save (story) that has been added to a Shareable List. This is the admin version which
-does not include item: Item.
-"""
-type ShareableListItemAdmin {
-  """
-  A unique string identifier in UUID format.
-  """
-  externalId: ID!
-  """
-  The Parser Item ID.
-  """
-  itemId: ID!
-  """
-  The URL of the story saved to a list.
-  """
-  url: Url!
-  """
-  The title of the story. Supplied by the Parser.
-  May not be available for URLs that cannot be resolved.
-  Not editable by the Pocket user, as are all the other
-  Parser-supplied story properties below.
-  """
-  title: String
-  """
-  The excerpt of the story. Supplied by the Parser.
-  """
-  excerpt: String
-  """
-  User generated note to accompany this list item.
-  """
-  note: String
-  """
-  The URL of the thumbnail image illustrating the story. Supplied by the Parser.
-  """
-  imageUrl: Url
-  """
-  The name of the publisher for this story. Supplied by the Parser.
-  """
-  publisher: String
-  """
-  A comma-separated list of story authors. Supplied by the Parser.
-  """
-  authors: String
-  """
-  The custom sort order of stories within a list. Defaults to 1.
-  """
-  sortOrder: Int!
-  """
-  The timestamp of when this story was added to the list by its owner.
-  """
-  createdAt: ISOString!
-  """
-  The timestamp of when the story was last updated. Not used for the MVP.
-  """
-  updatedAt: ISOString!
-}
-
-interface ShareableListInterface {
-  """
-  A unique string identifier in UUID format.
-  """
-  externalId: ID!
-  """
-  The user who created this shareable list.
-  """
-  user: User!
-  """
-  A URL-ready identifier of the list. Generated from the title
-  of the list when it's first made public. Unique per user.
-  """
-  slug: String
-  """
-  The title of the list. Provided by the Pocket user.
-  """
-  title: String!
-  """
-  Optional text description of a Shareable List. Provided by the Pocket user.
-  """
-  description: String
-  """
-  The status of the list. Defaults to PRIVATE.
-  """
-  status: ShareableListVisibility!
-  """
-  The moderation status of the list. Defaults to VISIBLE.
-  """
-  moderationStatus: ShareableListModerationStatus!
-  """
-  The timestamp of when the list was created by its owner.
-  """
-  createdAt: ISOString!
-  """
-  The timestamp of when the list was last updated by its owner
-  or a member of the moderation team.
-  """
-  updatedAt: ISOString!
-  """
-  Pocket Saves that have been added to this list by the Pocket user.
-  """
-  listItems: [ShareableListItemUnion!]!
-  """
-  The visibility of notes added to list items for this list.
-  """
-  listItemNoteVisibility: ShareableListVisibility!
 }
 
 """

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -23,6 +23,11 @@ A URL to a web page or image.
 scalar Url
 
 """
+An abstract GraphQL type which returns a public or admin ShareableListItem.
+"""
+union ShareableListItemUnion = ShareableListItem | ShareableListItemAdmin
+
+"""
 The visibility levels used (e.g. list, list item note) in the Shareable List API. Defaults to PRIVATE - visible only to its owner.
 """
 enum ShareableListVisibility {
@@ -126,6 +131,64 @@ type ShareableListItem {
   updatedAt: ISOString!
 }
 
+"""
+A Pocket Save (story) that has been added to a Shareable List. This is the admin version which
+does not include item: Item.
+"""
+type ShareableListItemAdmin {
+  """
+  A unique string identifier in UUID format.
+  """
+  externalId: ID!
+  """
+  The Parser Item ID.
+  """
+  itemId: ID!
+  """
+  The URL of the story saved to a list.
+  """
+  url: Url!
+  """
+  The title of the story. Supplied by the Parser.
+  May not be available for URLs that cannot be resolved.
+  Not editable by the Pocket user, as are all the other
+  Parser-supplied story properties below.
+  """
+  title: String
+  """
+  The excerpt of the story. Supplied by the Parser.
+  """
+  excerpt: String
+  """
+  User generated note to accompany this list item.
+  """
+  note: String
+  """
+  The URL of the thumbnail image illustrating the story. Supplied by the Parser.
+  """
+  imageUrl: Url
+  """
+  The name of the publisher for this story. Supplied by the Parser.
+  """
+  publisher: String
+  """
+  A comma-separated list of story authors. Supplied by the Parser.
+  """
+  authors: String
+  """
+  The custom sort order of stories within a list. Defaults to 1.
+  """
+  sortOrder: Int!
+  """
+  The timestamp of when this story was added to the list by its owner.
+  """
+  createdAt: ISOString!
+  """
+  The timestamp of when the story was last updated. Not used for the MVP.
+  """
+  updatedAt: ISOString!
+}
+
 interface ShareableListInterface {
   """
   A unique string identifier in UUID format.
@@ -168,7 +231,7 @@ interface ShareableListInterface {
   """
   Pocket Saves that have been added to this list by the Pocket user.
   """
-  listItems: [ShareableListItem!]!
+  listItems: [ShareableListItemUnion!]!
 }
 
 """

--- a/src/admin/resolvers/fragments.gql.ts
+++ b/src/admin/resolvers/fragments.gql.ts
@@ -1,5 +1,5 @@
 import { gql } from 'graphql-tag';
-import { ShareableListItemPublicProps } from '../../shared/fragments.gql';
+import { ShareableListItemAdminProps } from '../../shared/fragments.gql';
 
 export const ShareableListCompleteProps = gql`
   fragment ShareableListCompleteProps on ShareableListComplete {
@@ -16,8 +16,8 @@ export const ShareableListCompleteProps = gql`
     moderationDetails
     restorationReason
     listItems {
-      ...ShareableListItemPublicProps
+      ...ShareableListItemAdminProps
     }
   }
-  ${ShareableListItemPublicProps}
+  ${ShareableListItemAdminProps}
 `;

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -1,7 +1,6 @@
 import { PocketDefaultScalars } from '@pocket-tools/apollo-utils';
 import { searchShareableList } from './queries/ShareableList';
 import { moderateShareableList } from './mutations/ShareableList';
-import { ItemResolver } from '../../shared/resolvers/fields/Item';
 import { UserResolver } from '../../shared/resolvers/fields/User';
 import { PrismaBigIntResolver } from '../../shared/resolvers/fields/PrismaBigInt';
 
@@ -10,9 +9,8 @@ export const resolvers = {
   ShareableListComplete: {
     user: UserResolver,
   },
-  ShareableListItem: {
+  ShareableListItemAdmin: {
     itemId: PrismaBigIntResolver,
-    item: ItemResolver,
   },
   Query: { searchShareableList },
   Mutation: { moderateShareableList },

--- a/src/admin/resolvers/queries/ShareableList.integration.ts
+++ b/src/admin/resolvers/queries/ShareableList.integration.ts
@@ -141,7 +141,6 @@ describe('admin queries: ShareableList', () => {
 
       expect(listItem.externalId).not.to.be.empty;
       expect(listItem.itemId).to.equal('3834701731');
-      expect(listItem.item.itemId).to.equal('3834701731');
       expect(listItem.url).to.equal(shareableListItem.url);
       expect(listItem.title).to.equal(shareableListItem.title);
       expect(listItem.excerpt).to.equal(shareableListItem.excerpt);

--- a/src/shared/fragments.gql.ts
+++ b/src/shared/fragments.gql.ts
@@ -26,6 +26,27 @@ export const ShareableListItemPublicProps = gql`
 
 /**
  * This GraphQL fragment contains all the properties that must be available
+ * in the Admin Pocket Graph for a Shareable List Item (does not expose item: Item).
+ */
+export const ShareableListItemAdminProps = gql`
+  fragment ShareableListItemAdminProps on ShareableListItemAdmin {
+    externalId
+    itemId
+    url
+    title
+    excerpt
+    note
+    imageUrl
+    publisher
+    authors
+    sortOrder
+    createdAt
+    updatedAt
+  }
+`;
+
+/**
+ * This GraphQL fragment contains all the properties that must be available
  * in the Public Pocket Graph for a Shareable List.
  */
 export const ShareableListPublicProps = gql`


### PR DESCRIPTION
## Goal

**Problem:** Curation admin tool (or any client using the admin graph) generates the admin types and uses them to get data. Parser `Item` type generated by the admin tool has `itemId`, `givenUrl` and `normalUrl` required. The shareable lists API only resolves `itemId` on `Item`. Front-end tool complains about type mismatch as it uses the generated types. 

**Solution:** The admin graph does not need `item: Item` returned for shareable list item, so creating an admin type to use specifically for the admin graph. 

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-510](https://getpocket.atlassian.net/browse/OSL-510)
