### PR TITLE
OSL-499: Extending SavedItem & adding shareableListTotalCount property

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -1,3 +1,17 @@
+extend type SavedItem @key(fields: "url") {
+  """
+  key field to identify the SavedItem entity in the List API service
+  """
+  url: String! @external
+
+  #Note more properties exist here but are defined in another service.
+
+  """
+  Indicates in how many shareable lists a save is in
+  """
+  shareableListTotalCount: Int
+}
+
 """
 A user-created list of Pocket saves that can be shared publicly.
 """

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -2,7 +2,7 @@ extend schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(
     url: "https://specs.apollo.dev/federation/v2.3"
-    import: ["@key", "@composeDirective"]
+    import: ["@key", "@composeDirective", "@external"]
   )
   # The link directive is required to federate @constraint
   # It doesn't actually have to be a real spec, but it would be good

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -1,6 +1,7 @@
 import { PocketDefaultScalars } from '@pocket-tools/apollo-utils';
 import { PrismaBigIntResolver } from '../../shared/resolvers/fields/PrismaBigInt';
 import { ItemResolver } from '../../shared/resolvers/fields/Item';
+import { SavedItemResolver } from '../../shared/resolvers/fields/SavedItem';
 import { UserResolver } from '../../shared/resolvers/fields/User';
 import {
   getShareableList,
@@ -22,6 +23,9 @@ import {
 
 export const resolvers = {
   ...PocketDefaultScalars,
+  SavedItem: {
+    shareableListTotalCount: SavedItemResolver,
+  },
   ShareableList: {
     user: UserResolver,
   },

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -101,7 +101,7 @@ describe('public mutations: ShareableList', () => {
     });
 
     it('should not create a new List without userId in header', async () => {
-      const title = faker.random.words(2);
+      const title = faker.lorem.words(2);
       const data: CreateShareableListInput = {
         title: title,
         description: faker.lorem.sentences(2),
@@ -308,7 +308,7 @@ describe('public mutations: ShareableList', () => {
 
     it('should not create List with a title of more than 100 chars', async () => {
       const data: CreateShareableListInput = {
-        title: faker.random.alpha(LIST_TITLE_MAX_CHARS + 1),
+        title: faker.string.alpha(LIST_TITLE_MAX_CHARS + 1),
         description: faker.lorem.sentences(2),
       };
       const result = await request(app)
@@ -330,7 +330,7 @@ describe('public mutations: ShareableList', () => {
     it('should not create List with a description of more than 200 chars', async () => {
       const data: CreateShareableListInput = {
         title: `Katerina's List`,
-        description: faker.random.alpha(LIST_DESCRIPTION_MAX_CHARS + 1),
+        description: faker.string.alpha(LIST_DESCRIPTION_MAX_CHARS + 1),
       };
       const result = await request(app)
         .post(graphQLUrl)
@@ -1157,7 +1157,7 @@ describe('public mutations: ShareableList', () => {
     it('should not update List with a title of more than 100 chars', async () => {
       const data: UpdateShareableListInput = {
         externalId: nonPilotUserList.externalId,
-        title: faker.random.alpha(LIST_TITLE_MAX_CHARS + 1),
+        title: faker.string.alpha(LIST_TITLE_MAX_CHARS + 1),
       };
 
       const result = await request(app)
@@ -1182,7 +1182,7 @@ describe('public mutations: ShareableList', () => {
     it('should not update List with a description of more than 200 chars', async () => {
       const data: UpdateShareableListInput = {
         externalId: nonPilotUserList.externalId,
-        description: faker.random.alpha(LIST_DESCRIPTION_MAX_CHARS + 1),
+        description: faker.string.alpha(LIST_DESCRIPTION_MAX_CHARS + 1),
       };
 
       const result = await request(app)

--- a/src/public/resolvers/mutations/ShareableListItem.integration.ts
+++ b/src/public/resolvers/mutations/ShareableListItem.integration.ts
@@ -211,7 +211,7 @@ describe('public mutations: ShareableListItem', () => {
         url: 'https://www.test.com/this-is-a-story',
         title: 'A story is a story',
         excerpt: '<blink>The best story ever told</blink>',
-        note: faker.random.alpha(LIST_ITEM_NOTE_MAX_CHARS + 1),
+        note: faker.string.alpha(LIST_ITEM_NOTE_MAX_CHARS + 1),
         imageUrl: 'https://www.test.com/thumbnail.jpg',
         publisher: 'The London Times',
         authors: 'Charles Dickens, Mark Twain',
@@ -526,7 +526,7 @@ describe('public mutations: ShareableListItem', () => {
     it('should not update a shareable list item with a note greater than 300 characters', async () => {
       const data: UpdateShareableListItemInput = {
         externalId: listItem1.externalId,
-        note: faker.random.alpha(LIST_ITEM_NOTE_MAX_CHARS + 1),
+        note: faker.string.alpha(LIST_ITEM_NOTE_MAX_CHARS + 1),
         sortOrder: 3,
       };
 

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -24,6 +24,7 @@ import {
   GET_SHAREABLE_LIST,
   GET_SHAREABLE_LIST_PUBLIC,
   GET_SHAREABLE_LISTS,
+  SHAREABLE_LIST_TOTAL_COUNT_SAVEDITEM_REFERENCE_RESOLVER,
 } from './sample-queries.gql';
 import { ACCESS_DENIED_ERROR } from '../../../shared/constants';
 
@@ -73,7 +74,6 @@ describe('public queries: ShareableList', () => {
       userId: parseInt(publicUserHeaders.userId),
       title: 'This is a test list',
     });
-
     // create another list
     shareableList2 = await createShareableListHelper(db, {
       userId: parseInt(publicUserHeaders.userId),
@@ -736,6 +736,143 @@ describe('public queries: ShareableList', () => {
 
       expect(listItems[2].sortOrder).to.equal(1);
       expect(listItems[3].sortOrder).to.equal(2);
+    });
+  });
+  describe('SavedItem reference resolver', () => {
+    it('should resolve on a shareableListTotalCount on SavedItem', async () => {
+      const url = 'https://burning-rose.com';
+      // create a new shareableListItem for list1
+      await createShareableListItemHelper(db, {
+        list: shareableList,
+        url: url,
+      });
+      // create the same list item for list2, for the same user
+      await createShareableListItemHelper(db, {
+        list: shareableList2,
+        url: url,
+      });
+
+      // Run the query we're testing
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(publicUserHeaders)
+        .send({
+          query: print(SHAREABLE_LIST_TOTAL_COUNT_SAVEDITEM_REFERENCE_RESOLVER),
+          variables: {
+            url: url,
+          },
+        });
+
+      expect(result.body.errors).to.be.undefined;
+      expect(result.body.data._entities.length).to.equal(1);
+      expect(result.body.data._entities[0].url).to.equal(
+        'https://burning-rose.com'
+      );
+      // user has 2 lists containing the same save
+      expect(result.body.data._entities[0].shareableListTotalCount).to.equal(2);
+    });
+
+    it('should not count list item matching save url but belonging to another user', async () => {
+      const url = 'https://hangover-hotel.com';
+      // create a new shareableListItem for list1
+      await createShareableListItemHelper(db, {
+        list: shareableList,
+        url: url,
+      });
+
+      // create a new list
+      const shareableList3 = await createShareableListHelper(db, {
+        userId: 6523806750,
+        title: 'This is a fun test list',
+      });
+
+      // create the same list item for list3, for different user
+      await createShareableListItemHelper(db, {
+        list: shareableList3,
+        url: url,
+      });
+
+      // Run the query we're testing for public userId 987654321
+      let result = await request(app)
+        .post(graphQLUrl)
+        .set(publicUserHeaders)
+        .send({
+          query: print(SHAREABLE_LIST_TOTAL_COUNT_SAVEDITEM_REFERENCE_RESOLVER),
+          variables: {
+            url: url,
+          },
+        });
+
+      expect(result.body.errors).to.be.undefined;
+      expect(result.body.data._entities.length).to.equal(1);
+      expect(result.body.data._entities[0].url).to.equal(
+        'https://hangover-hotel.com'
+      );
+      // user has only one list containing save with given url
+      expect(result.body.data._entities[0].shareableListTotalCount).to.equal(1);
+
+      // Run the query again but for userId 6523806750
+      result = await request(app)
+        .post(graphQLUrl)
+        .set({
+          userId: shareableList3.userId.toString(),
+        })
+        .send({
+          query: print(SHAREABLE_LIST_TOTAL_COUNT_SAVEDITEM_REFERENCE_RESOLVER),
+          variables: {
+            url: url,
+          },
+        });
+
+      expect(result.body.errors).to.be.undefined;
+      expect(result.body.data._entities.length).to.equal(1);
+      expect(result.body.data._entities[0].url).to.equal(
+        'https://hangover-hotel.com'
+      );
+      // user has only one list containing save with given url
+      expect(result.body.data._entities[0].shareableListTotalCount).to.equal(1);
+    });
+
+    it('should return 0 for shareableListTotalCount when a SavedItem is not in a ShareableList', async () => {
+      const url = 'https://not-saved-item.com';
+
+      // Run the query we're testing
+      const result = await request(app)
+        .post(graphQLUrl)
+        .set(publicUserHeaders)
+        .send({
+          query: print(SHAREABLE_LIST_TOTAL_COUNT_SAVEDITEM_REFERENCE_RESOLVER),
+          variables: {
+            url: url,
+          },
+        });
+
+      expect(result.body.errors).to.be.undefined;
+      expect(result.body.data._entities[0].shareableListTotalCount).to.equal(0);
+    });
+
+    it('should not resolve when no userId', async () => {
+      const url = 'https://white-lotus.com';
+      // create a new shareableListItem for list1
+      await createShareableListItemHelper(db, {
+        list: shareableList,
+        url: url,
+      });
+
+      // Run the query we're testing
+      const result = await request(app)
+        .post(graphQLUrl)
+        .send({
+          query: print(SHAREABLE_LIST_TOTAL_COUNT_SAVEDITEM_REFERENCE_RESOLVER),
+          variables: {
+            url: url,
+          },
+        });
+
+      expect(result.body.errors).to.be.undefined;
+      expect(result.body.data._entities[0].shareableListTotalCount).to.equal(
+        null
+      );
     });
   });
 });

--- a/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/src/public/resolvers/queries/sample-queries.gql.ts
@@ -36,3 +36,14 @@ export const SHAREABLE_LISTS_PILOT_USER = gql`
     shareableListsPilotUser
   }
 `;
+
+export const SHAREABLE_LIST_TOTAL_COUNT_SAVEDITEM_REFERENCE_RESOLVER = gql`
+  query ($url: String) {
+    _entities(representations: { url: $url, __typename: "SavedItem" }) {
+      ... on SavedItem {
+        url
+        shareableListTotalCount
+      }
+    }
+  }
+`;

--- a/src/shared/resolvers/fields/SavedItem.ts
+++ b/src/shared/resolvers/fields/SavedItem.ts
@@ -11,13 +11,14 @@ export async function getShareableListTotalCount(
   db: PrismaClient,
   userId: number | bigint,
   url: string
-): Promise<number> {
+): Promise<number | null> {
   if (!userId) {
     return null;
   }
-  // find shareable list items where url matches given
-  // and where parent list belongs to current user
-  const listItems = await db.listItem.findMany({
+
+  // get the total count of listItems where url is matching
+  // AND parent list belongs to current userId
+  const totalCount = await db.listItem.count({
     where: {
       url,
       list: {
@@ -25,11 +26,14 @@ export async function getShareableListTotalCount(
       },
     },
   });
-  const totalCount = listItems.length;
 
   return totalCount;
 }
 
-export async function SavedItemResolver(parent, _, { userId, db }) {
+export async function SavedItemResolver(
+  parent,
+  _,
+  { userId, db }
+): Promise<number | null> {
   return await getShareableListTotalCount(db, userId, parent.url);
 }

--- a/src/shared/resolvers/fields/SavedItem.ts
+++ b/src/shared/resolvers/fields/SavedItem.ts
@@ -1,0 +1,35 @@
+import { PrismaClient } from '@prisma/client';
+
+/**
+ * Returns the total count of shareable lists a save is in by the save url.
+ *
+ * @param db
+ * @param userId
+ * @param url
+ */
+export async function getShareableListTotalCount(
+  db: PrismaClient,
+  userId: number | bigint,
+  url: string
+): Promise<number> {
+  if (!userId) {
+    return null;
+  }
+  // find shareable list items where url matches given
+  // and where parent list belongs to current user
+  const listItems = await db.listItem.findMany({
+    where: {
+      url,
+      list: {
+        userId,
+      },
+    },
+  });
+  const totalCount = listItems.length;
+
+  return totalCount;
+}
+
+export async function SavedItemResolver(parent, _, { userId, db }) {
+  return await getShareableListTotalCount(db, userId, parent.url);
+}

--- a/src/snowplow/events.spec.ts
+++ b/src/snowplow/events.spec.ts
@@ -24,7 +24,7 @@ describe('Snowplow event helpers', () => {
   let consoleSpy;
 
   const shareableList: ShareableListComplete = {
-    externalId: faker.datatype.uuid(),
+    externalId: faker.string.uuid(),
     userId: BigInt(12345),
     slug: null,
     title: 'Fake Random Title',
@@ -42,20 +42,20 @@ describe('Snowplow event helpers', () => {
   };
 
   const shareableListItem: ShareableListItem = {
-    externalId: faker.datatype.uuid(),
+    externalId: faker.string.uuid(),
     itemId: BigInt(98765),
     url: `${faker.internet.url()}/${faker.lorem.slug(5)}`,
-    title: faker.random.words(5),
+    title: faker.lorem.words(5),
     excerpt: faker.lorem.sentences(2),
     note: faker.lorem.sentences(1),
-    imageUrl: faker.image.cats(),
+    imageUrl: faker.image.urlLoremFlickr({ category: 'cats' }),
     publisher: faker.company.name(),
-    authors: `${faker.name.fullName()},${faker.name.fullName()}`,
-    sortOrder: faker.datatype.number(),
+    authors: `${faker.person.firstName()},${faker.person.firstName()}`,
+    sortOrder: faker.number.int(),
     createdAt: new Date('2023-01-01 10:10:10'),
     updatedAt: new Date('2023-01-01 10:10:10'),
   };
-  const shareableListItemExternalId = faker.datatype.uuid();
+  const shareableListItemExternalId = faker.string.uuid();
 
   beforeEach(() => {
     // we mock the send method on EventBridgeClient

--- a/src/test/helpers/createShareableListHelper.ts
+++ b/src/test/helpers/createShareableListHelper.ts
@@ -26,10 +26,10 @@ export async function createShareableListHelper(
   prisma: PrismaClient,
   data: ListHelperInput
 ): Promise<List> {
-  const listTitle = data.title ?? faker.random.words(2);
+  const listTitle = data.title ?? faker.lorem.words(2);
 
   const input: ListHelperInput = {
-    userId: data.userId ?? faker.datatype.number(),
+    userId: data.userId ?? faker.number.int(),
     title: listTitle,
     description: data.description ?? faker.lorem.sentences(2),
     slug: data.slug ?? undefined,

--- a/src/test/helpers/createShareableListItemHelper.ts
+++ b/src/test/helpers/createShareableListItemHelper.ts
@@ -28,15 +28,15 @@ export async function createShareableListItemHelper(
 ): Promise<ListItem> {
   const input = {
     listId: data.list.id,
-    itemId: data.itemId ?? faker.datatype.number(),
+    itemId: data.itemId ?? faker.number.bigInt(),
     url: data.url ?? `${faker.internet.url()}/${faker.lorem.slug(5)}`,
-    title: data.title ?? faker.random.words(5),
+    title: data.title ?? faker.lorem.words(5),
     excerpt: data.excerpt ?? faker.lorem.sentences(2),
     // if `null` is passed in, do not add a note to the list item
     note: data.note === undefined ? faker.lorem.sentences(2) : data.note,
-    imageUrl: data.imageUrl ?? faker.image.cats(),
+    imageUrl: data.imageUrl ?? faker.image.urlLoremFlickr({ category: 'cats' }),
     publisher: data.publisher ?? faker.company.name(),
-    authors: data.authors ?? faker.name.fullName(),
+    authors: data.authors ?? faker.person.fullName(),
     // allow sortOrder to fall back to db default if no specific order given
     sortOrder: data.sortOrder ?? undefined,
   };


### PR DESCRIPTION
## Goal

* Extending `SavedItem` type & adding an additional `shareableListTotalCount` property to indicate in how many shareable lists a save is (via `url`). See [slack thread](https://pocket.slack.com/archives/C04HWMUKLN5/p1684804833654229) for discussion.



## Tickets

- [https://getpocket.atlassian.net/browse/OSL-499](https://getpocket.atlassian.net/browse/OSL-499)
