### PR TITLE
refactor(Item): use givenUrl for Item connection

### DIFF
--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -61,8 +61,8 @@ type User @key(fields: "id", resolvable: false) {
 """
 Resolve by reference the Item entity to connect ShareableListItems to Items.
 """
-type Item @key(fields: "itemId", resolvable: false) {
-  itemId: String!
+type Item @key(fields: "givenUrl", resolvable: false) {
+  givenUrl: Url!
 }
 
 """

--- a/src/public/resolvers/mutations/ShareableList.integration.ts
+++ b/src/public/resolvers/mutations/ShareableList.integration.ts
@@ -272,7 +272,7 @@ describe('public mutations: ShareableList', () => {
       expect(listItem.title).to.equal(listItemData.title);
       expect(listItem.url).to.equal(listItemData.url);
       expect(listItem.itemId).to.equal(listItemData.itemId);
-      expect(listItem.item.itemId).to.equal(listItemData.itemId);
+      expect(listItem.item.givenUrl).to.equal(listItemData.url);
       expect(listItem.excerpt).to.equal(listItemData.excerpt);
       expect(listItem.imageUrl).to.equal(listItemData.imageUrl);
       expect(listItem.publisher).to.equal(listItemData.publisher);

--- a/src/public/resolvers/mutations/ShareableListItem.integration.ts
+++ b/src/public/resolvers/mutations/ShareableListItem.integration.ts
@@ -263,7 +263,7 @@ describe('public mutations: ShareableListItem', () => {
       const listItem = result.body.data.createShareableListItem;
       expect(listItem.externalId).not.to.be.empty;
       expect(listItem.itemId).to.equal(data.itemId);
-      expect(listItem.item.itemId).to.equal(data.itemId);
+      expect(listItem.item.givenUrl).to.equal(data.url);
       expect(listItem.url).to.equal(data.url);
       expect(listItem.title).to.equal(data.title);
       expect(listItem.excerpt).to.equal(
@@ -314,7 +314,7 @@ describe('public mutations: ShareableListItem', () => {
 
       expect(listItem.externalId).not.to.be.empty;
       expect(listItem.itemId).to.equal(data.itemId);
-      expect(listItem.item.itemId).to.equal(data.itemId);
+      expect(listItem.item.givenUrl).to.equal(data.url);
       expect(listItem.url).to.equal(data.url);
       expect(listItem.title).to.equal(data.title);
       expect(listItem.excerpt).to.equal(
@@ -407,7 +407,7 @@ describe('public mutations: ShareableListItem', () => {
       const listItem = result.body.data.createShareableListItem;
       expect(listItem.externalId).not.to.be.empty;
       expect(listItem.itemId).to.equal(data.itemId);
-      expect(listItem.item.itemId).to.equal(data.itemId);
+      expect(listItem.item.givenUrl).to.equal(data.url);
       expect(listItem.url).to.equal(data.url);
       expect(listItem.title).to.equal(data.title);
       expect(listItem.excerpt).to.equal(data.excerpt);

--- a/src/public/resolvers/queries/ShareableList.integration.ts
+++ b/src/public/resolvers/queries/ShareableList.integration.ts
@@ -225,7 +225,7 @@ describe('public queries: ShareableList', () => {
       // to make sure they're all there
       listItems.forEach((listItem) => {
         expect(listItem.itemId).not.to.be.empty;
-        expect(listItem.item.itemId).not.to.be.empty;
+        expect(listItem.item.givenUrl).not.to.be.empty;
         expect(listItem.url).not.to.be.empty;
         expect(listItem.title).not.to.be.empty;
         expect(listItem.excerpt).not.to.be.empty;
@@ -465,7 +465,7 @@ describe('public queries: ShareableList', () => {
       // to make sure they're all there
       listItems.forEach((listItem) => {
         expect(listItem.itemId).not.to.be.empty;
-        expect(listItem.item.itemId).not.to.be.empty;
+        expect(listItem.item.givenUrl).not.to.be.empty;
         expect(listItem.url).not.to.be.empty;
         expect(listItem.title).not.to.be.empty;
         expect(listItem.excerpt).not.to.be.empty;
@@ -539,7 +539,7 @@ describe('public queries: ShareableList', () => {
       // to make sure they're all there
       result.body.data.shareableListPublic.listItems.forEach((listItem) => {
         expect(listItem.itemId).not.to.be.empty;
-        expect(listItem.item.itemId).not.to.be.empty;
+        expect(listItem.item.givenUrl).not.to.be.empty;
         expect(listItem.url).not.to.be.empty;
         expect(listItem.title).not.to.be.empty;
         expect(listItem.excerpt).not.to.be.empty;
@@ -693,7 +693,7 @@ describe('public queries: ShareableList', () => {
       // to make sure they're all there for the first List
       listItems.forEach((listItem) => {
         expect(listItem.itemId).not.to.be.empty;
-        expect(listItem.item.itemId).not.to.be.empty;
+        expect(listItem.item.givenUrl).not.to.be.empty;
         expect(listItem.url).not.to.be.empty;
         expect(listItem.title).not.to.be.empty;
         expect(listItem.excerpt).not.to.be.empty;
@@ -715,7 +715,7 @@ describe('public queries: ShareableList', () => {
       // to make sure they're all there for the second List
       listItems.forEach((listItem) => {
         expect(listItem.itemId).not.to.be.empty;
-        expect(listItem.item.itemId).not.to.be.empty;
+        expect(listItem.item.givenUrl).not.to.be.empty;
         expect(listItem.url).not.to.be.empty;
         expect(listItem.title).not.to.be.empty;
         expect(listItem.excerpt).not.to.be.empty;

--- a/src/shared/fragments.gql.ts
+++ b/src/shared/fragments.gql.ts
@@ -9,7 +9,7 @@ export const ShareableListItemPublicProps = gql`
     externalId
     itemId
     item {
-      itemId
+      givenUrl
     }
     url
     title

--- a/src/shared/resolvers/fields/Item.ts
+++ b/src/shared/resolvers/fields/Item.ts
@@ -9,6 +9,6 @@
 export const ItemResolver = (parent, args, context, info) => {
   // very basic data transformation!
   return {
-    itemId: parent.itemId.toString(),
+    givenUrl: parent.url,
   };
 };


### PR DESCRIPTION
## Goal

use `givenUrl` for Item connection (instead of `itemId`). the current `itemId` connection (we think) is causing issues connecting to an `Item` > `SavedItem`. this is a hopeful fix for that issue.

see [this long slack thread](https://pocket.slack.com/archives/C03QVL4SU/p1684867901864509) for some details.

## Tickets

- https://getpocket.atlassian.net/browse/OSL-528