### PR TITLE
refactor(lambda errors): do not throw errors when no lambda handler

### DIFF
--- a/lambda/events/index.ts
+++ b/lambda/events/index.ts
@@ -11,21 +11,22 @@ import { handlers } from './handlers';
  */
 export async function processor(event: SQSEvent): Promise<SQSBatchResponse> {
   const batchFailures: SQSBatchItemFailure[] = [];
+
   for await (const record of event.Records) {
     try {
       const message = JSON.parse(JSON.parse(record.body).Message);
-      if (handlers[message['detail-type']] == null) {
-        throw new Error(
-          `Unable to retrieve handler for detail-type='${message['detail-type']}'`
-        );
+      const handler = handlers[message['detail-type']];
+
+      if (handler !== undefined) {
+        await handler(record);
       }
-      await handlers[message['detail-type']](record);
     } catch (error) {
       console.log(error);
       Sentry.captureException(error);
       batchFailures.push({ itemIdentifier: record.messageId });
     }
   }
+
   return { batchItemFailures: batchFailures };
 }
 


### PR DESCRIPTION
## Goal

do not throw errors when no lambda handler exists for the event bridge SNS > SQS message type.

- list API sends a bunch of events, only one of which we want to handle in this lambda, so we don't want to error on the others.

## Implementation Decisions

didn't think we needed to error or even log when a handler isn't found, as this is going to happen ALL THE TIME now that we're subscribing to list API events.
