### PR TITLE
OSL-550: fixing lambda uri config

### DIFF
--- a/.aws/src/SQSLambda.ts
+++ b/.aws/src/SQSLambda.ts
@@ -44,8 +44,8 @@ export class SQSLambda extends Resource {
             config.environment === 'Prod' ? 'production' : 'development',
           SHAREABLE_LISTS_API_URI:
             config.environment === 'Prod'
-              ? 'https://shareablelistsapi.readitlater.com/'
-              : 'https://shareablelistsapi.getpocket.dev/',
+              ? 'https://shareablelistsapi.readitlater.com'
+              : 'https://shareablelistsapi.getpocket.dev',
         },
         vpcConfig: {
           securityGroupIds: vpc.defaultSecurityGroups.ids,


### PR DESCRIPTION
## Goal

shareable list data was not getting deleted due to url config: `https://shareablelistsapi.readitlater.com//deleteUserData`. Removing extra `/` from lambda AWS URI env variable.

## Todos

- [x] deployed to dev & tested with an event via lambda console

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-550](https://getpocket.atlassian.net/browse/OSL-550)
