### PR TITLE
feat(archive): downgrade from tier1 to tier2 alerting

### DIFF
--- a/.aws/package-lock.json
+++ b/.aws/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@pocket-tools/terraform-modules": "4.16.1"
+        "@pocket-tools/terraform-modules": "4.16.2"
       },
       "devDependencies": {
         "@pocket-tools/tsconfig": "2.0.1",
@@ -460,9 +460,9 @@
       "deprecated": "this package has been deprecated, use `ci-info` instead"
     },
     "node_modules/@pocket-tools/terraform-modules": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@pocket-tools/terraform-modules/-/terraform-modules-4.16.1.tgz",
-      "integrity": "sha512-Y/wwPz2OoWQYCeS00ivfj547DNl0jCUDZTkvqCFg8XJBpmR1ZVJyl6ZqFdquscqqYlOXpDjx5cPpcPKiuCleQg==",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/@pocket-tools/terraform-modules/-/terraform-modules-4.16.2.tgz",
+      "integrity": "sha512-4S1FvuEPyGnii6WJ2EjYDbYegLvxKTev1agM91cqzPVlOZ8TTe83lLsMj3y+88ZBl5Mg1/FCF6IfaFi8RbooYA==",
       "dependencies": {
         "@cdktf/provider-archive": "4.0.0",
         "@cdktf/provider-aws": "11.0.9",
@@ -471,7 +471,7 @@
         "@cdktf/provider-null": "4.0.1",
         "@cdktf/provider-pagerduty": "4.0.3",
         "@cdktf/provider-time": "4.0.0",
-        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/commons": "^3.0.0",
         "cdktf": "0.14.3",
         "cdktf-cli": "0.14.3",
         "constructs": "10.1.215",
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/@sinonjs/commons": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -2697,9 +2697,9 @@
       }
     },
     "node_modules/jsii-srcmak": {
-      "version": "0.1.922",
-      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.922.tgz",
-      "integrity": "sha512-Rgp14vWo9TXGB2oRfeVsvWDS3Cotz9Rpj1jOCIza4OBH5IYvs2EDVo4xorpXCZEm95Rz+papyCko+/Lgyb63kg==",
+      "version": "0.1.923",
+      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.923.tgz",
+      "integrity": "sha512-DzySV86GwBnYuLqaFhv4C3s6bD0shs/NW41fHuHITY04pFFvxbadi74tfnu2Zv4XZFgZe7RDoygDUQRqV/tGXQ==",
       "dependencies": {
         "fs-extra": "^9.1.0",
         "jsii": "~5.1.1",

--- a/.aws/package.json
+++ b/.aws/package.json
@@ -12,7 +12,7 @@
     "lint-fix": "eslint --fix \"src/**/*.ts\""
   },
   "dependencies": {
-    "@pocket-tools/terraform-modules": "4.16.1"
+    "@pocket-tools/terraform-modules": "4.16.2"
   },
   "devDependencies": {
     "@pocket-tools/tsconfig": "2.0.1",

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -103,9 +103,9 @@ class ShareableListsAPI extends TerraformStack {
     new PocketAwsSyntheticChecks(this, 'synthetics', {
       alarmTopicArn:
         config.environment === 'Prod'
-          ? shareableListPagerduty.snsCriticalAlarmTopic.arn
-          : '', // this should be improved, empty string recreates updates constantly as is in cdktf
-      environment: process.env.NODE_ENV === 'development' ? 'Dev' : 'Prod', // yes we should use config.environment, but needs more refinment in module
+          ? shareableListPagerduty.snsNonCriticalAlarmTopic.arn
+          : null,
+      environment: config.environment,
       prefix: config.prefix,
       query: [
         {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Shareable Lists API
+[Service Docs](https://getpocket.atlassian.net/wiki/spaces/PE/pages/2891776041/Shareable+Lists)
 
 The API that manages the ability to create and share lists of related content.
 


### PR DESCRIPTION
We're out of the tier 1 alerting period for shareable lists api (agreed to originally to cover period when a lot of media was focused on the new feature).

As such, moving this to tier 2 alerting, which means alert response during business hours only (which translates currently to alerts via email).