### PR TITLE
OSL-561: SQS for batch delete shareable list items

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -48,4 +48,5 @@ export const config = {
       listEvents: `PocketEventBridge-${environment}-ListEventTopic`,
     },
   },
+  sqsBatchDeleteQueueName: `${name}-${environment}-Batch-Delete-Consumer-Queue`,
 };

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -14,6 +14,7 @@ import {
   ApplicationRedis,
   ApplicationRDSCluster,
   ApplicationSqsSnsTopicSubscription,
+  ApplicationSQSQueue,
   PocketALBApplication,
   PocketAwsSyntheticChecks,
   PocketECSCodePipeline,
@@ -86,6 +87,14 @@ class ShareableListsAPI extends TerraformStack {
         dependsOn: [lambda.sqsQueueResource as SqsQueue],
       }
     );
+
+    // SQS to queue shareable list items for deletion
+    new ApplicationSQSQueue(this, 'batch-delete-consumer-queue', {
+      name: config.sqsBatchDeleteQueueName,
+      tags: config.tags,
+      //need to set maxReceiveCount to enable DLQ
+      maxReceiveCount: 2,
+    });
 
     const shareableListPagerduty = this.createPagerDuty();
 


### PR DESCRIPTION
## Goal

Creating a new SQS to queue shareable list items for deletion

## Todos

- [x] tested in dev (queue created: https://us-east-1.console.aws.amazon.com/sqs/v2/home?region=us-east-1#/queues/https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F410318598490%2FShareableListsApi-Dev-Batch-Delete-Consumer-Queue)


## Tickets

- [https://getpocket.atlassian.net/browse/OSL-561](https://getpocket.atlassian.net/browse/OSL-561)
