### PR TITLE
OSL-573: Remove ShareableListItemAdmin type from schema

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -21,64 +21,6 @@ enum ShareableListModerationReason {
   PHISHING
 }
 
-"""
-A Pocket Save (story) that has been added to a Shareable List. This is the admin version which
-does not include the Parser Item.
-"""
-type ShareableListItemAdmin {
-  """
-  A unique string identifier in UUID format.
-  """
-  externalId: ID!
-  """
-  The Parser Item ID.
-  """
-  itemId: ID!
-  """
-  The URL of the story saved to a list.
-  """
-  url: Url!
-  """
-  The title of the story. Supplied by the Parser.
-  May not be available for URLs that cannot be resolved.
-  Not editable by the Pocket user, as are all the other
-  Parser-supplied story properties below.
-  """
-  title: String
-  """
-  The excerpt of the story. Supplied by the Parser.
-  """
-  excerpt: String
-  """
-  User generated note to accompany this list item.
-  """
-  note: String
-  """
-  The URL of the thumbnail image illustrating the story. Supplied by the Parser.
-  """
-  imageUrl: Url
-  """
-  The name of the publisher for this story. Supplied by the Parser.
-  """
-  publisher: String
-  """
-  A comma-separated list of story authors. Supplied by the Parser.
-  """
-  authors: String
-  """
-  The custom sort order of stories within a list. Defaults to 1.
-  """
-  sortOrder: Int!
-  """
-  The timestamp of when this story was added to the list by its owner.
-  """
-  createdAt: ISOString!
-  """
-  The timestamp of when the story was last updated. Not used for the MVP.
-  """
-  updatedAt: ISOString!
-}
-
 type ShareableListComplete {
   """
   A unique string identifier in UUID format.
@@ -121,7 +63,7 @@ type ShareableListComplete {
   """
   Pocket Saves that have been added to this list by the Pocket user.
   """
-  listItems: [ShareableListItemAdmin!]!
+  listItems: [ShareableListItem!]!
   """
   The visibility of notes added to list items for this list.
   """

--- a/src/admin/resolvers/fragments.gql.ts
+++ b/src/admin/resolvers/fragments.gql.ts
@@ -1,5 +1,5 @@
 import { gql } from 'graphql-tag';
-import { ShareableListItemAdminProps } from '../../shared/fragments.gql';
+import { ShareableListItemPublicProps } from '../../shared/fragments.gql';
 
 export const ShareableListCompleteProps = gql`
   fragment ShareableListCompleteProps on ShareableListComplete {
@@ -16,8 +16,8 @@ export const ShareableListCompleteProps = gql`
     moderationDetails
     restorationReason
     listItems {
-      ...ShareableListItemAdminProps
+      ...ShareableListItemPublicProps
     }
   }
-  ${ShareableListItemAdminProps}
+  ${ShareableListItemPublicProps}
 `;

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -9,7 +9,7 @@ export const resolvers = {
   ShareableListComplete: {
     user: UserResolver,
   },
-  ShareableListItemAdmin: {
+  ShareableListItem: {
     itemId: PrismaBigIntResolver,
   },
   Query: { searchShareableList },

--- a/src/shared/fragments.gql.ts
+++ b/src/shared/fragments.gql.ts
@@ -23,27 +23,6 @@ export const ShareableListItemPublicProps = gql`
 
 /**
  * This GraphQL fragment contains all the properties that must be available
- * in the Admin Pocket Graph for a Shareable List Item (does not expose item: Item).
- */
-export const ShareableListItemAdminProps = gql`
-  fragment ShareableListItemAdminProps on ShareableListItemAdmin {
-    externalId
-    itemId
-    url
-    title
-    excerpt
-    note
-    imageUrl
-    publisher
-    authors
-    sortOrder
-    createdAt
-    updatedAt
-  }
-`;
-
-/**
- * This GraphQL fragment contains all the properties that must be available
  * in the Public Pocket Graph for a Shareable List.
  */
 export const ShareableListPublicProps = gql`


### PR DESCRIPTION
## Goal
This is part of the foundational refactor rollback. Removes `ShareableListItemAdmin` type from admin schema, updates resolver and tests.

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-573](https://getpocket.atlassian.net/browse/OSL-573)