### PR TITLE
OSL-576: send list item metadata to Snowplow

### DIFF
--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -63,22 +63,22 @@ export type ShareableListItem = Prisma.ListItemGetPayload<
  * Once Parser metata is removed from the db and code, switch back to the original
  * type definition and delete this type definition.
  */
-export const shareableListItemSelectFieldsTemp =
-  Prisma.validator<Prisma.ListItemSelect>()({
-    externalId: true,
-    itemId: true,
-    url: true,
-    note: true,
-    sortOrder: true,
-    createdAt: true,
-    updatedAt: true,
-  });
-const shareableListItemTemp = Prisma.validator<Prisma.ListItemArgs>()({
-  select: shareableListItemSelectFieldsTemp,
-});
-export type ShareableListItemTemp = Prisma.ListItemGetPayload<
-  typeof shareableListItemTemp
->;
+// export const shareableListItemSelectFieldsTemp =
+//   Prisma.validator<Prisma.ListItemSelect>()({
+//     externalId: true,
+//     itemId: true,
+//     url: true,
+//     note: true,
+//     sortOrder: true,
+//     createdAt: true,
+//     updatedAt: true,
+//   });
+// const shareableListItemTemp = Prisma.validator<Prisma.ListItemArgs>()({
+//   select: shareableListItemSelectFieldsTemp,
+// });
+// export type ShareableListItemTemp = Prisma.ListItemGetPayload<
+//   typeof shareableListItemTemp
+// >;
 
 /**
  * This is the shape of a shareable list object on the public Pocket Graph -

--- a/src/snowplow/events.spec.ts
+++ b/src/snowplow/events.spec.ts
@@ -6,7 +6,7 @@ import { Visibility, ModerationStatus } from '@prisma/client';
 import {
   ShareableListModerationReason,
   ShareableListComplete,
-  ShareableListItemTemp,
+  ShareableListItem,
 } from '../database/types';
 import {
   generateShareableListEventBridgePayload,
@@ -42,11 +42,16 @@ describe('Snowplow event helpers', () => {
     listItems: [],
   };
 
-  const shareableListItem: ShareableListItemTemp = {
+  const shareableListItem: ShareableListItem = {
     externalId: faker.string.uuid(),
     itemId: BigInt(98765),
     url: `${faker.internet.url()}/${faker.lorem.slug(5)}`,
+    title: faker.lorem.words(5),
+    excerpt: faker.lorem.sentences(2),
     note: faker.lorem.sentences(1),
+    imageUrl: faker.image.urlLoremFlickr({ category: 'cats' }),
+    publisher: faker.company.name(),
+    authors: `${faker.person.firstName()},${faker.person.firstName()}`,
     sortOrder: faker.number.int(),
     createdAt: new Date('2023-01-01 10:10:10'),
     updatedAt: new Date('2023-01-01 10:10:10'),
@@ -337,6 +342,18 @@ describe('Snowplow event helpers', () => {
     // url-> given_url
     expect(payload.shareableListItem.given_url).to.equal(shareableListItem.url);
 
+    // imageUrl-> image_url
+    expect(payload.shareableListItem.image_url).to.equal(
+      shareableListItem.imageUrl
+    );
+    // authors string getting mapped to array of strings
+    expect(JSON.stringify(payload.shareableListItem.authors)).to.equal(
+      JSON.stringify(shareableListItem.authors.split(','))
+    );
+    // publisher
+    expect(payload.shareableListItem.publisher).to.equal(
+      shareableListItem.publisher
+    );
     // note
     expect(payload.shareableListItem.note).to.equal(shareableListItem.note);
     // sortOrder -> sort_order

--- a/src/snowplow/events.ts
+++ b/src/snowplow/events.ts
@@ -5,10 +5,7 @@ import {
 import * as Sentry from '@sentry/node';
 import config from '../config/';
 import { eventBridgeClient } from '../aws/eventBridgeClient';
-import {
-  ShareableListComplete,
-  ShareableListItemTemp,
-} from '../database/types';
+import { ShareableListComplete, ShareableListItem } from '../database/types';
 import {
   EventBridgeEventType,
   EventBridgeEventOptions,
@@ -72,7 +69,7 @@ function transformAPIShareableListToSnowplowShareableList(
  * @param listExternalId
  */
 function transformAPIShareableListItemToSnowplowShareableListItem(
-  shareableListItem: ShareableListItemTemp,
+  shareableListItem: ShareableListItem,
   externalId: string,
   listExternalId: string
 ): SnowplowShareableListItem {
@@ -80,6 +77,17 @@ function transformAPIShareableListItemToSnowplowShareableListItem(
     shareable_list_item_external_id: externalId,
     shareable_list_external_id: listExternalId,
     given_url: shareableListItem.url,
+    title: shareableListItem.title ? shareableListItem.title : undefined,
+    excerpt: shareableListItem.excerpt ? shareableListItem.excerpt : undefined,
+    image_url: shareableListItem.imageUrl
+      ? shareableListItem.imageUrl
+      : undefined,
+    authors: shareableListItem.authors
+      ? shareableListItem.authors.split(',')
+      : undefined,
+    publisher: shareableListItem.publisher
+      ? shareableListItem.publisher
+      : undefined,
     note: shareableListItem.note ? shareableListItem.note : undefined,
     sort_order: shareableListItem.sortOrder,
     created_at: Math.floor(shareableListItem.createdAt.getTime() / 1000),
@@ -116,7 +124,7 @@ export function generateShareableListEventBridgePayload(
  */
 export function generateShareableListItemEventBridgePayload(
   eventType: EventBridgeEventType,
-  shareableListItem: ShareableListItemTemp,
+  shareableListItem: ShareableListItem,
   externalId: string,
   listExternalId: string
 ): ShareableListItemEventBusPayload {

--- a/src/snowplow/types.ts
+++ b/src/snowplow/types.ts
@@ -1,8 +1,5 @@
 import { Visibility, ModerationStatus } from '@prisma/client';
-import {
-  ShareableListComplete,
-  ShareableListItemTemp,
-} from '../database/types';
+import { ShareableListComplete, ShareableListItem } from '../database/types';
 
 export type ShareableListEventBusPayload = {
   eventType: EventBridgeEventType;
@@ -29,7 +26,7 @@ export enum EventBridgeEventType {
 
 export interface EventBridgeEventOptions {
   shareableList?: ShareableListComplete;
-  shareableListItem?: ShareableListItemTemp;
+  shareableListItem?: ShareableListItem;
   shareableListItemExternalId?: string;
   listExternalId?: string;
   isShareableListEventType?: boolean;
@@ -63,6 +60,11 @@ export type SnowplowShareableListItem = {
   shareable_list_item_external_id: string;
   shareable_list_external_id: string;
   given_url: string;
+  title?: string;
+  excerpt?: string;
+  image_url?: string;
+  authors?: string[];
+  publisher?: string;
   note?: string;
   sort_order: number;
   created_at: number; // snowplow schema requires this field in seconds


### PR DESCRIPTION
## Goal

This is part of the foundational refactor rollback. Adding back the list item metadata to Snowplow type and sending to event bridge.

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-576](https://getpocket.atlassian.net/browse/OSL-576)
