### PR TITLE
chore(rollback): remove SQS for queueing items for deletion

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -48,5 +48,4 @@ export const config = {
       listEvents: `PocketEventBridge-${environment}-ListEventTopic`,
     },
   },
-  sqsBatchDeleteQueueName: `${name}-${environment}-Batch-Delete-Consumer-Queue`,
 };

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -14,7 +14,6 @@ import {
   ApplicationRedis,
   ApplicationRDSCluster,
   ApplicationSqsSnsTopicSubscription,
-  ApplicationSQSQueue,
   PocketALBApplication,
   PocketAwsSyntheticChecks,
   PocketECSCodePipeline,
@@ -87,14 +86,6 @@ class ShareableListsAPI extends TerraformStack {
         dependsOn: [lambda.sqsQueueResource as SqsQueue],
       }
     );
-
-    // SQS to queue shareable list items for deletion
-    new ApplicationSQSQueue(this, 'batch-delete-consumer-queue', {
-      name: config.sqsBatchDeleteQueueName,
-      tags: config.tags,
-      //need to set maxReceiveCount to enable DLQ
-      maxReceiveCount: 2,
-    });
 
     const shareableListPagerduty = this.createPagerDuty();
 


### PR DESCRIPTION
## Goal

remove SQS for queueing items for deletion. a revert of #245.

- part of the shelf stable work

## Tickets

- https://getpocket.atlassian.net/browse/OSL-580