### PR TITLE
OSL-577: block ability to make lists public

### DIFF
--- a/.circleci/scripts/setup_aws.sh
+++ b/.circleci/scripts/setup_aws.sh
@@ -2,7 +2,9 @@
 set -e
 
 sudo apt-get update && sudo apt-get install -y python3-pip
-pip3 install awscli-local awscli
+# using --no-build-isolation flag for now, remove when issue is fixed (AWS CLI)
+# https://github.com/aws/aws-cli/issues/8036
+pip3 install awscli-local awscli --no-build-isolation
 
 for Script in .docker/localstack/*.sh ; do
     bash "$Script"

--- a/package-lock.json
+++ b/package-lock.json
@@ -527,6 +527,55 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.354.0.tgz",
+      "integrity": "sha512-zHhOU0nbxtwVBeuR4HJQyKjh5eBth+n2wULZet83RwMPT1EICAJbREKWbBW6Cyg395Lxtuc41Ie4lQZoKx2how==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.354.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-node": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/md5-js": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.354.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.354.0.tgz",
@@ -841,6 +890,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/md5-js": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.347.0.tgz",
+      "integrity": "sha512-mChE+7DByTY9H4cQ6fnWp2x5jf8e6OZN+AdLp6WQ+W99z35zBeqBxVmgm8ziJwkMIrkSTv9j3Y7T9Ve3RIcSfg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-content-length": {
       "version": "3.347.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
@@ -930,6 +989,20 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.347.0.tgz",
+      "integrity": "sha512-TSBTQoOVe9cDm9am4NOov1YZxbQ3LPBl7Ex0jblDFgUXqE9kNU3Kx/yc8edOLcq+5AFrgqT0NFD7pwFlQPh3KQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
@@ -5170,11 +5243,7 @@
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.14.3.tgz",
       "integrity": "sha512-sVxp6xfzEoOCejixLgeaQo9mQPEImFa7JSWoOMIyxlA0NFVPrEWMvPcfM5iONCd1m8tU6w++RZG0Q9bLPn3Lgw==",
-      "bundleDependencies": [
-        "archiver",
-        "json-stable-stringify",
-        "semver"
-      ],
+      "bundleDependencies": ["archiver", "json-stable-stringify", "semver"],
       "dependencies": {
         "archiver": "5.3.1",
         "json-stable-stringify": "^1.0.2",
@@ -7595,9 +7664,7 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "hasInstallScript": true,
       "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "os": ["darwin"],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -9822,9 +9889,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
-      "engines": [
-        "node >= 0.2.0"
-      ]
+      "engines": ["node >= 0.2.0"]
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
@@ -10527,6 +10592,23 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -12126,9 +12208,7 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
-      "engines": [
-        "node >= 0.2.0"
-      ],
+      "engines": ["node >= 0.2.0"],
       "inBundle": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -527,55 +527,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sqs": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.354.0.tgz",
-      "integrity": "sha512-zHhOU0nbxtwVBeuR4HJQyKjh5eBth+n2wULZet83RwMPT1EICAJbREKWbBW6Cyg395Lxtuc41Ie4lQZoKx2how==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.354.0",
-        "@aws-sdk/config-resolver": "3.354.0",
-        "@aws-sdk/credential-provider-node": "3.354.0",
-        "@aws-sdk/fetch-http-handler": "3.353.0",
-        "@aws-sdk/hash-node": "3.347.0",
-        "@aws-sdk/invalid-dependency": "3.347.0",
-        "@aws-sdk/md5-js": "3.347.0",
-        "@aws-sdk/middleware-content-length": "3.347.0",
-        "@aws-sdk/middleware-endpoint": "3.347.0",
-        "@aws-sdk/middleware-host-header": "3.347.0",
-        "@aws-sdk/middleware-logger": "3.347.0",
-        "@aws-sdk/middleware-recursion-detection": "3.347.0",
-        "@aws-sdk/middleware-retry": "3.354.0",
-        "@aws-sdk/middleware-sdk-sqs": "3.347.0",
-        "@aws-sdk/middleware-serde": "3.347.0",
-        "@aws-sdk/middleware-signing": "3.354.0",
-        "@aws-sdk/middleware-stack": "3.347.0",
-        "@aws-sdk/middleware-user-agent": "3.352.0",
-        "@aws-sdk/node-config-provider": "3.354.0",
-        "@aws-sdk/node-http-handler": "3.350.0",
-        "@aws-sdk/smithy-client": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
-        "@aws-sdk/util-defaults-mode-node": "3.354.0",
-        "@aws-sdk/util-endpoints": "3.352.0",
-        "@aws-sdk/util-retry": "3.347.0",
-        "@aws-sdk/util-user-agent-browser": "3.347.0",
-        "@aws-sdk/util-user-agent-node": "3.354.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "fast-xml-parser": "4.2.4",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.354.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.354.0.tgz",
@@ -890,16 +841,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/md5-js": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.347.0.tgz",
-      "integrity": "sha512-mChE+7DByTY9H4cQ6fnWp2x5jf8e6OZN+AdLp6WQ+W99z35zBeqBxVmgm8ziJwkMIrkSTv9j3Y7T9Ve3RIcSfg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-content-length": {
       "version": "3.347.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
@@ -989,20 +930,6 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.347.0.tgz",
-      "integrity": "sha512-TSBTQoOVe9cDm9am4NOov1YZxbQ3LPBl7Ex0jblDFgUXqE9kNU3Kx/yc8edOLcq+5AFrgqT0NFD7pwFlQPh3KQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
@@ -5243,7 +5170,11 @@
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.14.3.tgz",
       "integrity": "sha512-sVxp6xfzEoOCejixLgeaQo9mQPEImFa7JSWoOMIyxlA0NFVPrEWMvPcfM5iONCd1m8tU6w++RZG0Q9bLPn3Lgw==",
-      "bundleDependencies": ["archiver", "json-stable-stringify", "semver"],
+      "bundleDependencies": [
+        "archiver",
+        "json-stable-stringify",
+        "semver"
+      ],
       "dependencies": {
         "archiver": "5.3.1",
         "json-stable-stringify": "^1.0.2",
@@ -7664,7 +7595,9 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "hasInstallScript": true,
       "optional": true,
-      "os": ["darwin"],
+      "os": [
+        "darwin"
+      ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -9889,7 +9822,9 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
-      "engines": ["node >= 0.2.0"]
+      "engines": [
+        "node >= 0.2.0"
+      ]
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
@@ -10592,23 +10527,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -12208,7 +12126,9 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
-      "engines": ["node >= 0.2.0"],
+      "engines": [
+        "node >= 0.2.0"
+      ],
       "inBundle": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -527,55 +527,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sqs": {
-      "version": "3.354.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.354.0.tgz",
-      "integrity": "sha512-zHhOU0nbxtwVBeuR4HJQyKjh5eBth+n2wULZet83RwMPT1EICAJbREKWbBW6Cyg395Lxtuc41Ie4lQZoKx2how==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.354.0",
-        "@aws-sdk/config-resolver": "3.354.0",
-        "@aws-sdk/credential-provider-node": "3.354.0",
-        "@aws-sdk/fetch-http-handler": "3.353.0",
-        "@aws-sdk/hash-node": "3.347.0",
-        "@aws-sdk/invalid-dependency": "3.347.0",
-        "@aws-sdk/md5-js": "3.347.0",
-        "@aws-sdk/middleware-content-length": "3.347.0",
-        "@aws-sdk/middleware-endpoint": "3.347.0",
-        "@aws-sdk/middleware-host-header": "3.347.0",
-        "@aws-sdk/middleware-logger": "3.347.0",
-        "@aws-sdk/middleware-recursion-detection": "3.347.0",
-        "@aws-sdk/middleware-retry": "3.354.0",
-        "@aws-sdk/middleware-sdk-sqs": "3.347.0",
-        "@aws-sdk/middleware-serde": "3.347.0",
-        "@aws-sdk/middleware-signing": "3.354.0",
-        "@aws-sdk/middleware-stack": "3.347.0",
-        "@aws-sdk/middleware-user-agent": "3.352.0",
-        "@aws-sdk/node-config-provider": "3.354.0",
-        "@aws-sdk/node-http-handler": "3.350.0",
-        "@aws-sdk/smithy-client": "3.347.0",
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/url-parser": "3.347.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
-        "@aws-sdk/util-defaults-mode-node": "3.354.0",
-        "@aws-sdk/util-endpoints": "3.352.0",
-        "@aws-sdk/util-retry": "3.347.0",
-        "@aws-sdk/util-user-agent-browser": "3.347.0",
-        "@aws-sdk/util-user-agent-node": "3.354.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@smithy/protocol-http": "^1.0.1",
-        "@smithy/types": "^1.0.0",
-        "fast-xml-parser": "4.2.4",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.354.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.354.0.tgz",
@@ -890,16 +841,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/md5-js": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.347.0.tgz",
-      "integrity": "sha512-mChE+7DByTY9H4cQ6fnWp2x5jf8e6OZN+AdLp6WQ+W99z35zBeqBxVmgm8ziJwkMIrkSTv9j3Y7T9Ve3RIcSfg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-content-length": {
       "version": "3.347.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
@@ -989,20 +930,6 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.347.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.347.0.tgz",
-      "integrity": "sha512-TSBTQoOVe9cDm9am4NOov1YZxbQ3LPBl7Ex0jblDFgUXqE9kNU3Kx/yc8edOLcq+5AFrgqT0NFD7pwFlQPh3KQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.347.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
@@ -10600,23 +10527,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",

--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -207,7 +207,7 @@ type Mutation {
   """
   deleteShareableList(externalId: ID!): ShareableList!
   """
-  Updates a Shareable List. This includes making it public.
+  Updates a Shareable List. Cannot make a list public.
   """
   updateShareableList(data: UpdateShareableListInput!): ShareableList!
   """

--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -4,6 +4,7 @@ import {
   UserInputError,
 } from '@pocket-tools/apollo-utils';
 import { Visibility, ModerationStatus, PrismaClient } from '@prisma/client';
+// import slugify from 'slugify';
 import {
   CreateShareableListInput,
   ModerateShareableListInput,
@@ -20,7 +21,11 @@ import {
   ACCESS_DENIED_ERROR,
   PRISMA_RECORD_NOT_FOUND,
 } from '../../shared/constants';
-import { getShareableList } from '../queries';
+import {
+  getShareableList,
+  // isPilotUser
+} from '../queries';
+// import config from '../../config';
 import { validateItemId } from '../../public/resolvers/utils';
 import { sendEventHelper } from '../../snowplow/events';
 import { EventBridgeEventType } from '../../snowplow/types';
@@ -113,8 +118,8 @@ export async function updateShareableList(
     throw new NotFoundError(`A list by that ID could not be found`);
   }
 
-  // we don't allow lists to be public anymore. block updates that try to make a list public
-  if (data.status === Visibility.PUBLIC) {
+  // we don't allow lists to be public anymore. block updates that try to make a list from PRIVATE to PUBLIC
+  if (list.status === Visibility.PRIVATE && data.status === Visibility.PUBLIC) {
     throw new ForbiddenError(ACCESS_DENIED_ERROR);
   }
 

--- a/src/database/mutations/ShareableList.ts
+++ b/src/database/mutations/ShareableList.ts
@@ -101,6 +101,8 @@ export async function createShareableList(
 
 /**
  * This mutation updates a shareable list, but does not allow to make a list public.
+ * Some of the blocks of code are commented out due to removing ability to make lists public.
+ * See ticket: https://getpocket.atlassian.net/browse/OSL-577
  *
  * @param db
  * @param data


### PR DESCRIPTION
## Goal

Blocking the ability to make a list `PUBLIC`. Current `PUBLIC` lists can stay `PUBLIC`, but if switched to `PRIVATE`, can no longer switch back to `PUBLIC`. Commented out relevant tests in case we ever turn back the functionality. 

## Tickets

- [https://getpocket.atlassian.net/browse/OSL-577](https://getpocket.atlassian.net/browse/OSL-577)
